### PR TITLE
Fix offer deduplication and add regression tests

### DIFF
--- a/job.py
+++ b/job.py
@@ -59,6 +59,11 @@ GEMINI_MODELS = [
 ]
 sys.path.insert(0, BASE_DIR)
 from src.cv_builder import generate_cv_pdf, get_cv_filename
+from src.offer_utils import (
+    deduplicate_offers_by_title_company,
+    extract_emails,
+    was_already_applied,
+)
 
 console = Console()
 CONFIG_PATH = os.path.join(BASE_DIR, "config.json")
@@ -117,25 +122,6 @@ def save_kb(kb):
 def is_configured():
     cfg = load_config()
     return all(cfg.get(k) for k in ["gemini_api_key", "smtp_email", "smtp_password", "profile"])
-
-def was_already_applied(kb, company, job_title, cooldown_days=30):
-    """Check if we already sent an application for the same job title + company.
-    Returns True if a matching application exists within the cooldown period.
-    Different job titles at the same company are allowed."""
-    cutoff = datetime.now() - timedelta(days=cooldown_days)
-    norm = lambda s: re.sub(r'[^a-z0-9]', '', (s or '').lower())
-    nc, nj = norm(company), norm(job_title)
-    for app in kb.get("applications", []):
-        ac, aj = norm(app.get("company", "")), norm(app.get("job_title", ""))
-        if nc == ac and nj == aj:
-            try:
-                app_date = datetime.fromisoformat(app["date"])
-                if app_date > cutoff:
-                    return True
-            except:
-                return True  # If date is unparseable, assume recent
-    return False
-
 
 # ══════════════════════════════════════════════
 # GEMINI
@@ -200,9 +186,6 @@ def send_email(cfg, to, subject, body, cv_path=None, max_retries=3):
             if attempt == max_retries - 1:
                 raise
             time.sleep(3)
-
-def extract_emails(text):
-    return list(set(re.findall(r'[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}', text)))
 
 def find_chrome():
     for p in [
@@ -970,18 +953,8 @@ def cmd_run(test_email=None, time_filter="24h", auto_apply=False):
     offers_with_email = [o for o in offers if o.get("contact_email")]
     offers_no_email = [o for o in offers if not o.get("contact_email")]
 
-    # Deduplicate within this batch: same job_title (normalized) → keep first occurrence
-    norm = lambda s: re.sub(r'[^a-z0-9]', '', (s or '').lower())
-    seen_batch = set()
-    deduped = []
-    for o in offers_with_email:
-        # Use normalized title + email as key (same offer reposted by different people = same title)
-        key = norm(o.get("job_title", ""))
-        if key and key in seen_batch:
-            continue
-        if key:
-            seen_batch.add(key)
-        deduped.append(o)
+    # Deduplicate within this batch: same normalized title + company
+    deduped = deduplicate_offers_by_title_company(offers_with_email)
     batch_dupes = len(offers_with_email) - len(deduped)
     offers_with_email = deduped
 
@@ -1025,7 +998,7 @@ def cmd_run(test_email=None, time_filter="24h", auto_apply=False):
     before_dedup = len(offers_with_email)
     offers_with_email = [
         o for o in offers_with_email
-        if not was_already_applied(kb, o.get("company", ""), o.get("job_title", ""))
+        if not was_already_applied(kb.get("applications", []), o.get("company", ""), o.get("job_title", ""))
     ]
     skipped = before_dedup - len(offers_with_email)
     if skipped:

--- a/src/offer_utils.py
+++ b/src/offer_utils.py
@@ -1,0 +1,44 @@
+import re
+from datetime import datetime, timedelta
+
+
+def normalize_text(value):
+    return re.sub(r"[^a-z0-9]", "", (value or "").lower())
+
+
+def extract_emails(text):
+    pattern = r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}"
+    return list(set(re.findall(pattern, text or "")))
+
+
+def was_already_applied(applications, company, job_title, cooldown_days=30):
+    cutoff = datetime.now() - timedelta(days=cooldown_days)
+    normalized_company = normalize_text(company)
+    normalized_title = normalize_text(job_title)
+
+    for app in applications or []:
+        app_company = normalize_text(app.get("company", ""))
+        app_title = normalize_text(app.get("job_title", ""))
+        if normalized_company == app_company and normalized_title == app_title:
+            try:
+                app_date = datetime.fromisoformat(app["date"])
+                if app_date > cutoff:
+                    return True
+            except Exception:
+                return True
+    return False
+
+
+def deduplicate_offers_by_title_company(offers):
+    seen = set()
+    deduped = []
+    for offer in offers or []:
+        key = (
+            normalize_text(offer.get("job_title", "")),
+            normalize_text(offer.get("company", "")),
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(offer)
+    return deduped

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -1,0 +1,40 @@
+import unittest
+
+from src.offer_utils import deduplicate_offers_by_title_company
+
+
+class DeduplicationTests(unittest.TestCase):
+    def test_keeps_same_title_for_different_companies(self):
+        offers = [
+            {"job_title": "Backend Developer", "company": "Acme"},
+            {"job_title": "Backend Developer", "company": "Globex"},
+        ]
+
+        result = deduplicate_offers_by_title_company(offers)
+
+        self.assertEqual(len(result), 2)
+
+    def test_deduplicates_same_title_same_company(self):
+        offers = [
+            {"job_title": "Backend Developer", "company": "Acme"},
+            {"job_title": "Backend Developer", "company": "Acme"},
+        ]
+
+        result = deduplicate_offers_by_title_company(offers)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["company"], "Acme")
+
+    def test_deduplicates_with_normalized_values(self):
+        offers = [
+            {"job_title": "Backend Developer!!", "company": "ACME Inc."},
+            {"job_title": " backend developer ", "company": "acme-inc"},
+        ]
+
+        result = deduplicate_offers_by_title_company(offers)
+
+        self.assertEqual(len(result), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,39 @@
+import unittest
+from datetime import datetime, timedelta
+
+from src.offer_utils import extract_emails, was_already_applied
+
+
+class UtilsTests(unittest.TestCase):
+    def test_extract_emails_returns_unique_values(self):
+        text = "Contacta a a@test.com o a@test.com y b@test.org"
+        emails = extract_emails(text)
+        self.assertEqual(set(emails), {"a@test.com", "b@test.org"})
+
+    def test_was_already_applied_true_within_cooldown(self):
+        applications = [
+            {
+                "company": "Acme",
+                "job_title": "Backend Developer",
+                "date": (datetime.now() - timedelta(days=5)).isoformat(),
+            }
+        ]
+        self.assertTrue(
+            was_already_applied(applications, "ACME", "backend developer", cooldown_days=30)
+        )
+
+    def test_was_already_applied_false_outside_cooldown(self):
+        applications = [
+            {
+                "company": "Acme",
+                "job_title": "Backend Developer",
+                "date": (datetime.now() - timedelta(days=45)).isoformat(),
+            }
+        ]
+        self.assertFalse(
+            was_already_applied(applications, "Acme", "Backend Developer", cooldown_days=30)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Fix deduplication logic to use normalized `job_title + company` instead of title-only.
- Extract reusable offer utility functions into `src/offer_utils.py`.
- Add unit tests for deduplication, cooldown matching, and email extraction.

## Test plan
- Run: `python -m unittest discover -s tests -p test_*.py`
- Verify same title + different company is kept.
- Verify same title + same company is deduplicated.
- Verify cooldown and email extraction tests pass.