### PR TITLE
feat(pipeline): mostrar decision del filter en vivo durante analisis

### DIFF
--- a/jobhunter/pipeline.py
+++ b/jobhunter/pipeline.py
@@ -182,6 +182,22 @@ def cmd_run(
                 "contact_email": a.get("contact_email"),
             })
 
+            # Mostrar decision inline encima del progress para que el usuario vea
+            # que analiza y por que acepta/rechaza cada post.
+            company = (a.get("company") or "").strip()
+            title = (a.get("job_title") or "").strip()
+            reason = (a.get("relevance_reason") or "").strip()
+            if a.get("is_job") and a.get("is_relevant", True):
+                label = f"    [green]\u2713[/green] {company or '-'} [dim]\u2014[/dim] {title or '-'}"
+            elif a.get("is_job"):
+                short = reason[:90] or "no relevante"
+                head = f"{company or '-'} \u2014 {title or '-'}" if (company or title) else "oferta no relevante"
+                label = f"    [yellow]\u2013[/yellow] [dim]{head}[/dim] [yellow]\u00b7[/yellow] [yellow]{short}[/yellow]"
+            else:
+                short = reason[:100] or "no es oferta"
+                label = f"    [dim red]\u2717[/dim red] [dim]{short}[/dim]"
+            console.print(label)
+
             if a.get("is_job") and a.get("is_relevant", True):
                 a["job_title"] = a.get("job_title") or "Software Developer"
                 a["company"] = a.get("company") or "Empresa"


### PR DESCRIPTION
## Problema
Durante la fase de analisis solo se ve el progress bar. El usuario no sabe que esta analizando ni por que se rechazan ofertas. Con 274 posts, el run dura ~30min a oscuras.

## Solucion

Encima del progress bar ahora aparece una linea por cada post con la decision del agent_filter:

~~~
    > Acme Corp - Backend Java Spring
    - Globex - Full Stack . requiere ingles avanzado que no tiene
    x no es oferta, es publicacion sobre tips de entrevistas
Analizando 12/274 [====>   ] 00:00:45
~~~

Rich Progress maneja bien los prints (van encima, el bar se queda abajo).

Colores:
- verde (check): oferta aceptada (is_job + is_relevant)
- amarillo (guion): es oferta pero no pasa filtros (work_mode / idioma / etc)
- rojo tenue (x): no es oferta

## Test plan

- [x] 125 tests verdes
- [ ] CI verde
- [ ] Probar visualmente con un run real (con --test para no enviar emails)