### PR TITLE
feat: mejor generacion de queries + diagnostico en vivo del filter

### DIFF
--- a/jobhunter/agents/query_generator.py
+++ b/jobhunter/agents/query_generator.py
@@ -1,0 +1,188 @@
+# -*- coding: utf-8 -*-
+"""Agente que genera queries de busqueda de LinkedIn a partir del perfil.
+
+Antes esta logica vivia inline en cmd_setup con un prompt que incluia las
+propias palabras del fallback robotico como 'inspiracion' y terminaba
+generando queries del tipo 'enviar CV X remoto'. Este modulo inyecta stack
+tecnico real, seniority estimada y nivel de ingles del usuario para que el
+modelo produzca queries mas cercanas al lenguaje real de reclutadores LATAM.
+"""
+import json
+
+from jobhunter.ai.gemini import call_gemini
+
+
+def _estimate_seniority(profile):
+    """Estimacion gruesa de seniority por cantidad de experiencias listadas."""
+    exps = profile.get("experience", []) or []
+    n = len(exps)
+    if n <= 1:
+        return "junior"
+    if n <= 3:
+        return "semi senior"
+    return "senior"
+
+
+def _english_level(cfg):
+    """Nivel de ingles declarado o None si no aparece."""
+    for lang in cfg.get("user_languages", []) or []:
+        name = (lang.get("language") or "").lower()
+        if name.startswith("ingl") or name.startswith("engl"):
+            return (lang.get("level") or "").strip()
+    return None
+
+
+def _english_is_limited(level):
+    """True si el nivel NO alcanza para ofertas 100% en ingles."""
+    if not level:
+        return True
+    low = level.lower()
+    return any(k in low for k in ("a1", "a2", "b1", "basico", "basic"))
+
+
+def _top_stack(profile, n=6):
+    """Aplana las skills declaradas y toma las primeras n sin categorizar."""
+    skills = profile.get("skills", {})
+    items = []
+    if isinstance(skills, dict):
+        for v in skills.values():
+            if isinstance(v, list):
+                items.extend(v)
+    elif isinstance(skills, list):
+        items = list(skills)
+    return [str(s).strip() for s in items if s][:n]
+
+
+def _sanitize(queries):
+    """Strip + dedupe case-insensitive + descarta no-strings y vacios."""
+    seen = set()
+    clean = []
+    for q in queries:
+        if not isinstance(q, str):
+            continue
+        q = q.strip()
+        k = q.lower()
+        if not q or k in seen:
+            continue
+        seen.add(k)
+        clean.append(q)
+    return clean
+
+
+def _fallback(cfg, stack, seniority, en_limited):
+    """Fallback programatico mejorado: usa stack y seniority reales.
+
+    El fallback anterior solo expandia 'enviar CV/busco/contratando/vacante' x
+    titulo generico. Este agrega combos con stack y varia mas las expresiones.
+    """
+    job_types = cfg.get("job_types_raw", "software developer")
+    wm_label = cfg.get("work_mode_label", "Cualquiera")
+    lang = cfg.get("search_languages", "3")
+
+    wm = wm_label.lower()
+    mode_es = {"remoto": "remoto", "hibrido": "hibrido", "presencial": "presencial", "cualquiera": ""}.get(wm, "")
+    mode_en = {"remoto": "remote", "hibrido": "hybrid", "presencial": "onsite", "cualquiera": ""}.get(wm, "")
+    sen = {"junior": "junior", "semi senior": "semi senior", "senior": "senior"}.get(seniority, "")
+
+    queries = []
+    titles = [j.strip() for j in job_types.split(",") if j.strip()][:3]
+
+    for jt in titles:
+        if lang in ("1", "3"):
+            queries.extend([
+                f"CV {jt} {mode_es}".strip(),
+                f"buscamos {jt} {mode_es}".strip(),
+                f"contratando {jt} {sen}".strip(),
+                f"vacante {jt} {mode_es}".strip(),
+                f"aplica {jt} enviar CV".strip(),
+                f"postulate {jt} {mode_es}".strip(),
+            ])
+        if lang == "2" or (lang == "3" and not en_limited):
+            queries.extend([
+                f"hiring {jt} {mode_en}".strip(),
+                f"we are hiring {jt}".strip(),
+                f"looking for {jt} {mode_en}".strip(),
+            ])
+
+    for tech in stack[:3]:
+        if lang in ("1", "3"):
+            queries.append(f"buscamos {tech} developer {mode_es}".strip())
+            queries.append(f"vacante {tech} {mode_es}".strip())
+
+    return _sanitize(queries)[:22]
+
+
+def generate_queries(cfg):
+    """Genera queries personalizadas. Retorna (queries, from_ai).
+
+    from_ai=False indica que Gemini fallo y se uso el fallback. El caller
+    (cmd_setup / cmd_optimize) deberia avisar al usuario en ese caso para
+    que decida si reintentar o seguir con las queries del fallback.
+    """
+    profile = cfg.get("profile", {})
+    job_types = cfg.get("job_types_raw", "software developer")
+    lang = cfg.get("search_languages", "3")
+    wm_label = cfg.get("work_mode_label", "Cualquiera")
+    location = cfg.get("user_location", "")
+
+    seniority = _estimate_seniority(profile)
+    en_level = _english_level(cfg)
+    en_limited = _english_is_limited(en_level)
+    stack = _top_stack(profile)
+
+    lang_label = {"1": "espanol", "2": "ingles", "3": "espanol e ingles"}.get(lang, "espanol e ingles")
+
+    if lang == "3" and en_limited:
+        effective_lang_rule = (
+            "Genera queries en espanol. Puedes mezclar terminos en ingles SOLO dentro de una query "
+            "en espanol (ej 'hiring Backend remoto Colombia'). NO generes queries 100% en ingles "
+            "porque el candidato tiene nivel de ingles limitado y esas ofertas se descartaran despues."
+        )
+    elif lang == "1":
+        effective_lang_rule = "Genera queries solo en espanol."
+    elif lang == "2":
+        effective_lang_rule = "Genera queries solo en ingles."
+    else:
+        effective_lang_rule = "Mezcla queries en espanol y en ingles."
+
+    stack_line = f"- Stack tecnico real del candidato: {', '.join(stack)}" if stack else ""
+    location_line = f"- Ubicacion: {location}" if location else ""
+    en_level_line = f"- Nivel de ingles real: {en_level}" if en_level else "- Nivel de ingles: no declarado"
+
+    prompt = f"""Eres un experto en reclutamiento IT en LinkedIn LATAM. Tu trabajo es generar queries para la barra de busqueda de LinkedIn seccion Contenido (posts), NO en la seccion Empleos. Las queries deben encontrar publicaciones de reclutadores o hiring managers que dejan email de contacto para recibir CVs.
+
+PERFIL DEL CANDIDATO:
+- Titulo actual: {profile.get('title', '?')}
+- Busca empleo como: {job_types}
+- Seniority estimada: {seniority}
+- Modalidad preferida: {wm_label}
+{location_line}
+{stack_line}
+- Idiomas de busqueda: {lang_label}
+{en_level_line}
+
+REGLAS:
+1. {effective_lang_rule}
+2. Genera entre 15 y 22 queries. Calidad sobre cantidad.
+3. Usa expresiones reales que reclutadores LATAM (Colombia, Mexico, Argentina, Chile) usan al publicar en LinkedIn. Piensa en lenguaje natural y coloquial de reclutadores, no en formulas genericas.
+4. Cada query debe ser corta (3-6 palabras), como alguien escribiria en la barra de busqueda.
+5. AL MENOS LA MITAD de las queries deben incluir el stack tecnico concreto del candidato (ej nombres de frameworks/lenguajes), no solo el titulo generico.
+6. Incluye variantes por seniority: si es "junior" usa junior/trainee; si es "semi senior" usa semi senior/SSR; si es "senior" usa senior/sr. NO mezcles seniorities lejanas.
+7. NO repitas queries con solo reordenar palabras.
+8. NO generes la mayoria de queries con el patron "enviar CV X" / "busco X" / "hiring X". Varia las expresiones: aplica, postulate, buscamos, contratando, vacante, incorporar, se busca, oportunidad, se necesita, estamos contratando, unete al equipo, etc.
+9. Si la modalidad no es "Cualquiera", incluirla en algunas queries (no en todas).
+
+JSON array: ["query1", "query2", ...]
+Responde SOLO el JSON array, sin texto adicional ni bloques de codigo."""
+
+    try:
+        result = call_gemini(cfg, prompt)
+        queries = json.loads(result)
+        if not isinstance(queries, list):
+            raise ValueError("respuesta no es una lista")
+        clean = _sanitize(queries)
+        if len(clean) < 5:
+            raise ValueError("pocas queries utiles")
+        return clean[:25], True
+    except Exception:
+        return _fallback(cfg, stack, seniority, en_limited), False

--- a/jobhunter/cli/setup.py
+++ b/jobhunter/cli/setup.py
@@ -307,68 +307,16 @@ SOLO JSON valido.""", b64, "application/pdf")
             idx += 1
 
     cfg["profile"] = profile
-    lang = cfg.get("search_languages", "3")
-    lang_label = {"1": "espanol", "2": "ingles", "3": "espanol e ingles"}.get(lang, "espanol e ingles")
-    wm_label = cfg.get("work_mode_label", "Cualquiera")
-    job_types = cfg.get("job_types_raw", "software developer")
-    location = cfg.get("user_location", "")
 
-    queries = []
-    location_line = "- Ubicacion: " + location if location else ""
+    from jobhunter.agents.query_generator import generate_queries
     with console.status("  [dim]Generando queries de busqueda con IA...[/dim]"):
-        try:
-            prompt = f"""Eres un experto en reclutamiento y busqueda de empleo en LinkedIn.
-Tu trabajo es generar queries de busqueda que encuentren PUBLICACIONES de reclutadores que estan buscando candidatos activamente en LinkedIn.
+        queries, from_ai = generate_queries(cfg)
 
-IMPORTANTE: Estas queries se usan en la barra de busqueda de LinkedIn, seccion "Contenido" (posts), NO en la seccion de empleos.
-Deben encontrar posts donde reclutadores publican ofertas con email de contacto para recibir CVs.
-
-PERFIL DEL CANDIDATO:
-- Busca empleo como: {job_types}
-- Modalidad: {wm_label}
-{location_line}
-- Idiomas de busqueda: {lang_label}
-
-REGLAS:
-- Genera EXACTAMENTE 20 queries variadas
-- Usa terminos que los reclutadores REALMENTE usan al publicar en LinkedIn (no terminos de buscador de empleo)
-- Incluye variaciones: "enviar CV", "buscamos", "contratando", "vacante", "hiring", "looking for", "send resume", "we are hiring", "join our team"
-- Mezcla el titulo exacto con variaciones del sector (ej: si busca "Backend Developer", incluir "desarrollador backend", "backend engineer", "ingeniero backend")
-- Si idioma es espanol: queries en espanol
-- Si idioma es ingles: queries en ingles
-- Si es ambos: mezcla queries en ambos idiomas
-- Si modalidad no es "Cualquiera", incluirla en algunas queries pero no en todas
-- Queries cortas (3-6 palabras), como alguien escribiria en la barra de busqueda
-- NO repitas queries similares con solo cambio de orden de palabras
-
-JSON array: ["query1", "query2", ...]
-SOLO el JSON array, nada mas."""
-            result = call_gemini(cfg, prompt)
-            queries = json.loads(result)
-            if not isinstance(queries, list) or len(queries) < 5:
-                raise ValueError("Pocas queries generadas")
-        except Exception:
-            pass
-
-    if not queries:
-        wm = wm_label.lower()
-        mode_terms_es = {"remoto": "remoto", "hibrido": "hibrido", "presencial": "presencial", "cualquiera": ""}
-        mode_terms_en = {"remoto": "remote", "hibrido": "hybrid", "presencial": "onsite", "cualquiera": ""}
-        for jt in [j.strip() for j in job_types.split(",") if j.strip()]:
-            if lang in ("1", "3"):
-                queries.extend([
-                    f"enviar CV {jt} {mode_terms_es.get(wm, '')}".strip(),
-                    f"busco {jt} {mode_terms_es.get(wm, '')}".strip(),
-                    f"contratando {jt} {mode_terms_es.get(wm, '')}".strip(),
-                    f"vacante {jt} {mode_terms_es.get(wm, '')}".strip(),
-                ])
-            if lang in ("2", "3"):
-                queries.extend([
-                    f"hiring {jt} {mode_terms_en.get(wm, '')}".strip(),
-                    f"looking for {jt} {mode_terms_en.get(wm, '')}".strip(),
-                    f"send CV {jt} {mode_terms_en.get(wm, '')}".strip(),
-                    f"job opening {jt} {mode_terms_en.get(wm, '')}".strip(),
-                ])
+    if not from_ai:
+        console.print(
+            "  [yellow]![/yellow] No se pudo generar queries con IA (API de Gemini fallo o sin cuota). "
+            "Se uso un fallback basico. Ejecuta [cyan]jobhunter optimize[/cyan] mas tarde para mejorarlas."
+        )
 
     cfg["search_queries"] = queries
     save_config(cfg)

--- a/jobhunter/pipeline.py
+++ b/jobhunter/pipeline.py
@@ -147,6 +147,7 @@ def cmd_run(
     console.print()
     console.print("  [bold dim]Analizando ofertas...[/bold dim]")
     offers = []
+    filter_decisions = []  # cada decision del agent_filter incluye relevance_reason
 
     with Progress(SpinnerColumn(), TextColumn("[progress.description]{task.description}"),
                   BarColumn(), TextColumn("{task.completed}/{task.total}"),
@@ -154,9 +155,33 @@ def cmd_run(
         task = prog.add_task("Analizando...", total=len(posts_with_emails))
         for post in posts_with_emails:
             if len(post.get("text","")) < 50:
+                filter_decisions.append({
+                    "post_url": post.get("post_url"),
+                    "post_preview": post.get("text", "")[:200],
+                    "is_job": False,
+                    "is_relevant": False,
+                    "relevance_reason": "skipped (text < 50 chars)",
+                })
                 prog.advance(task); continue
             ss = post.get("screenshots",[None])[0] if post.get("screenshots") else None
             a = agent_filter(cfg, post["text"], ss)
+
+            # Registrar TODAS las decisiones (aceptadas y rechazadas) para poder
+            # diagnosticar por que el filter esta descartando tanto. Sin esto el
+            # usuario ve 274 posts -> 1 oferta y no sabe que paso con los 273.
+            filter_decisions.append({
+                "post_url": post.get("post_url"),
+                "post_preview": post.get("text", "")[:200],
+                "is_job": bool(a.get("is_job")),
+                "is_relevant": bool(a.get("is_relevant", True)),
+                "relevance_reason": a.get("relevance_reason", ""),
+                "job_title": a.get("job_title"),
+                "company": a.get("company"),
+                "language": a.get("language"),
+                "work_mode": a.get("work_mode"),
+                "contact_email": a.get("contact_email"),
+            })
+
             if a.get("is_job") and a.get("is_relevant", True):
                 a["job_title"] = a.get("job_title") or "Software Developer"
                 a["company"] = a.get("company") or "Empresa"
@@ -495,7 +520,29 @@ def cmd_run(
 
     log = os.path.join(BASE_DIR, "output", "logs", f"run_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json")
     os.makedirs(os.path.dirname(log), exist_ok=True)
+    # Resumen por razon de rechazo para diagnostico rapido
+    reject_reasons = {}
+    for d in filter_decisions:
+        if not (d.get("is_job") and d.get("is_relevant", True)):
+            reason = d.get("relevance_reason") or "(sin razon)"
+            reject_reasons[reason] = reject_reasons.get(reason, 0) + 1
+    log_data = {
+        "run_date": datetime.now().isoformat(),
+        "mode": mode,
+        "stats": {
+            "posts_scraped": len(all_posts),
+            "posts_with_emails": len(posts_with_emails),
+            "filter_accepted": len(offers),
+            "filter_rejected": len(filter_decisions) - len(offers),
+            "reject_reasons_top": dict(sorted(reject_reasons.items(), key=lambda x: -x[1])[:10]),
+            "applications_attempted": len(results),
+            "sent": sent,
+            "errors": errors,
+        },
+        "filter_decisions": filter_decisions,
+        "applications": results,
+    }
     with open(log, "w", encoding="utf-8") as f:
-        json.dump(results, f, indent=2, ensure_ascii=False)
+        json.dump(log_data, f, indent=2, ensure_ascii=False)
 
 

--- a/jobhunter/pipeline.py
+++ b/jobhunter/pipeline.py
@@ -182,6 +182,22 @@ def cmd_run(
                 "contact_email": a.get("contact_email"),
             })
 
+            # Mostrar decision inline encima del progress para que el usuario vea
+            # que analiza y por que acepta/rechaza cada post.
+            company = (a.get("company") or "").strip()
+            title = (a.get("job_title") or "").strip()
+            reason = (a.get("relevance_reason") or "").strip()
+            if a.get("is_job") and a.get("is_relevant", True):
+                label = f"    [green]\u2713[/green] {company or '-'} [dim]\u2014[/dim] {title or '-'}"
+            elif a.get("is_job"):
+                short = reason[:90] or "no relevante"
+                head = f"{company or '-'} \u2014 {title or '-'}" if (company or title) else "oferta no relevante"
+                label = f"    [yellow]\u2013[/yellow] [dim]{head}[/dim] [yellow]\u00b7[/yellow] [yellow]{short}[/yellow]"
+            else:
+                short = reason[:100] or "no es oferta"
+                label = f"    [dim red]\u2717[/dim red] [dim]{short}[/dim]"
+            console.print(label)
+
             if a.get("is_job") and a.get("is_relevant", True):
                 a["job_title"] = a.get("job_title") or "Software Developer"
                 a["company"] = a.get("company") or "Empresa"

--- a/tests/test_agents_query_generator.py
+++ b/tests/test_agents_query_generator.py
@@ -1,0 +1,173 @@
+# -*- coding: utf-8 -*-
+import json
+import unittest
+from unittest.mock import patch
+
+from jobhunter.agents.query_generator import (
+    _english_is_limited,
+    _english_level,
+    _estimate_seniority,
+    _fallback,
+    _sanitize,
+    _top_stack,
+    generate_queries,
+)
+
+
+CFG_BASE = {
+    "profile": {
+        "title": "Backend Developer",
+        "skills": {"backend": ["Java", "Spring"], "other": ["Docker"]},
+        "experience": [{"role": "Dev"}, {"role": "Intern"}],
+    },
+    "job_types_raw": "Backend Developer, Full Stack Developer",
+    "search_languages": "3",
+    "work_mode_label": "Remoto",
+    "user_languages": [
+        {"language": "Espanol", "level": "Nativo"},
+        {"language": "Ingles", "level": "B1"},
+    ],
+    "gemini_api_key": "K",
+    "gemini_model": "gemini-2.5-flash",
+}
+
+
+class HelperTests(unittest.TestCase):
+    def test_seniority_junior_no_experience(self):
+        self.assertEqual(_estimate_seniority({"experience": []}), "junior")
+
+    def test_seniority_semi_senior_two_to_three(self):
+        self.assertEqual(_estimate_seniority({"experience": [1, 2]}), "semi senior")
+        self.assertEqual(_estimate_seniority({"experience": [1, 2, 3]}), "semi senior")
+
+    def test_seniority_senior_four_plus(self):
+        self.assertEqual(_estimate_seniority({"experience": [1, 2, 3, 4]}), "senior")
+
+    def test_english_level_extracted(self):
+        self.assertEqual(_english_level(CFG_BASE), "B1")
+
+    def test_english_level_none_when_missing(self):
+        self.assertIsNone(_english_level({"user_languages": [{"language": "Espanol", "level": "Nativo"}]}))
+
+    def test_english_is_limited_b1_and_below(self):
+        self.assertTrue(_english_is_limited("B1"))
+        self.assertTrue(_english_is_limited("A2"))
+        self.assertTrue(_english_is_limited("Basico"))
+        self.assertTrue(_english_is_limited(None))
+
+    def test_english_is_not_limited_b2_and_above(self):
+        self.assertFalse(_english_is_limited("B2"))
+        self.assertFalse(_english_is_limited("C1"))
+        self.assertFalse(_english_is_limited("Fluent"))
+
+    def test_top_stack_flattens_dict(self):
+        stack = _top_stack(CFG_BASE["profile"])
+        self.assertIn("Java", stack)
+        self.assertIn("Spring", stack)
+        self.assertIn("Docker", stack)
+
+    def test_top_stack_list_form(self):
+        stack = _top_stack({"skills": ["Python", "Django"]})
+        self.assertEqual(stack, ["Python", "Django"])
+
+    def test_sanitize_dedupe_case_insensitive(self):
+        clean = _sanitize(["Hola", "hola", "HOLA", "mundo", ""])
+        self.assertEqual(clean, ["Hola", "mundo"])
+
+    def test_sanitize_drops_non_strings(self):
+        clean = _sanitize(["ok", None, 42, "otra"])
+        self.assertEqual(clean, ["ok", "otra"])
+
+
+class GenerateQueriesAITests(unittest.TestCase):
+    @patch("jobhunter.agents.query_generator.call_gemini")
+    def test_ai_success_returns_from_ai_true(self, mock_call):
+        mock_call.return_value = json.dumps([
+            "buscamos backend java spring", "vacante backend semi senior",
+            "aplica backend developer remoto", "contratando developer NestJS",
+            "postulate Full Stack remoto", "se busca backend java",
+        ])
+        queries, from_ai = generate_queries(CFG_BASE)
+        self.assertTrue(from_ai)
+        self.assertGreaterEqual(len(queries), 5)
+
+    @patch("jobhunter.agents.query_generator.call_gemini")
+    def test_ai_fallback_on_exception(self, mock_call):
+        mock_call.side_effect = Exception("quota exceeded")
+        queries, from_ai = generate_queries(CFG_BASE)
+        self.assertFalse(from_ai)
+        self.assertGreater(len(queries), 0)
+
+    @patch("jobhunter.agents.query_generator.call_gemini")
+    def test_ai_fallback_when_not_a_list(self, mock_call):
+        mock_call.return_value = json.dumps({"queries": ["x"]})
+        queries, from_ai = generate_queries(CFG_BASE)
+        self.assertFalse(from_ai)
+
+    @patch("jobhunter.agents.query_generator.call_gemini")
+    def test_ai_fallback_when_too_few(self, mock_call):
+        mock_call.return_value = json.dumps(["one", "two"])
+        queries, from_ai = generate_queries(CFG_BASE)
+        self.assertFalse(from_ai)
+
+    @patch("jobhunter.agents.query_generator.call_gemini")
+    def test_prompt_includes_stack(self, mock_call):
+        mock_call.return_value = json.dumps(["a", "b", "c", "d", "e", "f"])
+        generate_queries(CFG_BASE)
+        prompt = mock_call.call_args.args[1]
+        self.assertIn("Java", prompt)
+        self.assertIn("Spring", prompt)
+
+    @patch("jobhunter.agents.query_generator.call_gemini")
+    def test_prompt_includes_seniority(self, mock_call):
+        mock_call.return_value = json.dumps(["a", "b", "c", "d", "e", "f"])
+        generate_queries(CFG_BASE)
+        prompt = mock_call.call_args.args[1]
+        self.assertIn("semi senior", prompt)
+
+    @patch("jobhunter.agents.query_generator.call_gemini")
+    def test_prompt_warns_limited_english(self, mock_call):
+        mock_call.return_value = json.dumps(["a", "b", "c", "d", "e", "f"])
+        generate_queries(CFG_BASE)
+        prompt = mock_call.call_args.args[1]
+        self.assertIn("NO generes queries 100% en ingles", prompt)
+
+    @patch("jobhunter.agents.query_generator.call_gemini")
+    def test_prompt_allows_english_when_not_limited(self, mock_call):
+        mock_call.return_value = json.dumps(["a", "b", "c", "d", "e", "f"])
+        cfg = dict(CFG_BASE, user_languages=[
+            {"language": "Espanol", "level": "Nativo"},
+            {"language": "Ingles", "level": "C1"},
+        ])
+        generate_queries(cfg)
+        prompt = mock_call.call_args.args[1]
+        self.assertNotIn("NO generes queries 100% en ingles", prompt)
+
+
+class FallbackTests(unittest.TestCase):
+    def test_fallback_includes_stack_combos(self):
+        stack = ["Java", "Spring"]
+        queries = _fallback(CFG_BASE, stack, "semi senior", en_limited=True)
+        joined = " ".join(queries).lower()
+        self.assertIn("java", joined)
+
+    def test_fallback_respects_limited_english(self):
+        stack = ["Java"]
+        queries = _fallback(CFG_BASE, stack, "junior", en_limited=True)
+        # Con ingles limitado y search_languages=3, NO debe haber queries puras en ingles
+        for q in queries:
+            # Una query pura en ingles tipicamente empieza con hiring/we are/looking
+            lower = q.lower()
+            self.assertFalse(
+                lower.startswith("hiring ") or lower.startswith("we are hiring") or lower.startswith("looking for"),
+                f"Query en ingles no deberia aparecer con ingles limitado: {q}",
+            )
+
+    def test_fallback_includes_english_when_not_limited(self):
+        queries = _fallback(CFG_BASE, ["Java"], "senior", en_limited=False)
+        lower = " ".join(queries).lower()
+        self.assertIn("hiring", lower)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Resumen

Dos mejoras motivadas por el feedback de un contribuidor que obtuvo 274 posts -> 1 oferta (0.36%):

1. **Nuevo query generator** ([#24](https://github.com/dev-gaspar/jobhunter/pull/24)): genera queries personalizadas con stack real + seniority + nivel de ingles. Avisa al usuario cuando cae al fallback.
2. **Decisiones del filter en vivo** ([#25](https://github.com/dev-gaspar/jobhunter/pull/25)): durante analisis muestra linea por post con decision (verde/amarillo/rojo) y razon de rechazo.
3. **Logs completos de decisiones** (parte de #24): `output/logs/run_*.json` ahora incluye `filter_decisions` y `reject_reasons_top` para diagnostico post-mortem.

## Test plan

- [x] 125 tests verdes (18 nuevos para query_generator)
- [ ] CI verde en este PR