### PR TITLE
fix: links de posts via portapapeles + gate de idioma de la publicacion

### DIFF
--- a/jobhunter/agents/filter.py
+++ b/jobhunter/agents/filter.py
@@ -5,6 +5,34 @@ import json
 from jobhunter.ai.gemini import call_gemini, call_gemini_vision
 from jobhunter.offers import extract_emails
 
+# search_languages ("1"=es, "2"=en, "3"=es+en) tambien define en que idiomas
+# puede estar escrita la publicacion. Gate deterministico ademas de la regla
+# del prompt: Gemini dejaba pasar posts en portugues porque "no requieren"
+# el idioma explicitamente.
+ALLOWED_LANGS = {"1": ("es",), "2": ("en",), "3": ("es", "en")}
+LANG_NAMES = {"es": "espanol", "en": "ingles"}
+
+
+def allowed_languages(cfg):
+    return ALLOWED_LANGS.get(str(cfg.get("search_languages", "3")), ("es", "en"))
+
+
+def enforce_language_gate(a, cfg):
+    """Marca is_relevant=False si la publicacion esta en un idioma no configurado."""
+    if not a.get("is_job") or not a.get("is_relevant", True):
+        return a
+    lang = (a.get("language") or "").strip().lower()[:2]
+    if not lang:
+        return a
+    allowed = allowed_languages(cfg)
+    if lang not in allowed:
+        nombres = ", ".join(LANG_NAMES.get(x, x) for x in allowed)
+        a["is_relevant"] = False
+        a["relevance_reason"] = (
+            "publicacion en idioma '" + lang + "': el perfil solo busca ofertas en " + nombres
+        )
+    return a
+
 
 def agent_filter(cfg, text, ss=None):
     """Analiza un post de LinkedIn y devuelve dict con is_job / is_relevant / datos."""
@@ -47,6 +75,8 @@ def agent_filter(cfg, text, ss=None):
 
     emails_line = ", ".join(emails) if emails else "ninguno"
     skills_str = json.dumps(profile_skills) if isinstance(profile_skills, dict) else str(profile_skills)[:500]
+    allowed = allowed_languages(cfg)
+    allowed_line = " o ".join(LANG_NAMES.get(x, x) + " (" + x + ")" for x in allowed)
 
     prompt = f"""ROLE: Eres un agente especializado en filtrar ofertas de trabajo de LinkedIn.
 Tu unico trabajo es analizar publicaciones y determinar si contienen ofertas REALES y RELEVANTES para este candidato.
@@ -69,6 +99,7 @@ REGLAS DE FILTRADO:
 - Relevante si el puesto tiene relacion con lo que busca el candidato: {job_types}
 {work_mode_rule}
 - Si la oferta REQUIERE un idioma con nivel avanzado o fluido que el candidato NO tiene a ese nivel, marcar is_relevant=false. Los idiomas del candidato son: {user_langs_str}
+- La publicacion debe estar escrita en {allowed_line}. Si esta escrita en OTRO idioma (por ejemplo portugues), marcar is_relevant=false aunque no exija ese idioma explicitamente
 - Extraer SIEMPRE el email si existe en el texto
 - Extraer empresa, titulo, descripcion COMPLETA con todos los detalles
 - Extraer requisitos especificos (habilidades, herramientas, anos de experiencia, idiomas, etc.)
@@ -88,6 +119,6 @@ SOLO JSON valido."""
             a["contact_email"] = None
         if emails and not a.get("contact_email"):
             a["contact_email"] = emails[0]
-        return a
+        return enforce_language_gate(a, cfg)
     except Exception as e:
         return {"is_job": False, "relevance_reason": str(e)}

--- a/jobhunter/pipeline.py
+++ b/jobhunter/pipeline.py
@@ -83,6 +83,7 @@ def cmd_run(
             browser = p.chromium.launch_persistent_context(
                 user_data_dir=SESSION_DIR, headless=True,
                 viewport={"width":1300,"height":850}, executable_path=chrome,
+                permissions=["clipboard-read", "clipboard-write"],
             )
             page = browser.pages[0] if browser.pages else browser.new_page()
             page.goto("https://www.linkedin.com/feed/", wait_until="domcontentloaded")
@@ -249,7 +250,7 @@ def cmd_run(
         if extra_wide:
             table.add_column("Salario", max_width=18, style="green")
         table.add_column("Email", max_width=26 if wide else 22, style="cyan")
-        table.add_column("Post", width=6, justify="center")
+        table.add_column("Post", max_width=20 if wide else 6, justify="left" if wide else "center")
         mode_icons = {"remote": "[green]Remoto[/green]", "hybrid": "[yellow]Hibrido[/yellow]", "onsite": "[red]Onsite[/red]", "unknown": "[dim]—[/dim]"}
         for i, o in enumerate(offers_with_email, 1):
             wm = mode_icons.get(o.get("work_mode", "unknown"), "[dim]—[/dim]")
@@ -260,7 +261,11 @@ def cmd_run(
             salary = o.get("salary") or "—"
             if str(salary).lower() in ("null", "none", "n/a", "no mencionado", "no especificado"):
                 salary = "—"
-            post_link = f"[link={o['post_url']}]Ver[/link]" if o.get("post_url") else "[dim]—[/dim]"
+            if o.get("post_url"):
+                shown = o["post_url"].replace("https://", "") if wide else "Ver"
+                post_link = f"[link={o['post_url']}]{shown}[/link]"
+            else:
+                post_link = "[dim]—[/dim]"
             if extra_wide:
                 table.add_row(str(i), o["job_title"][:28], o["company"][:16], wm, loc[:18], la, str(salary)[:18], o["contact_email"], post_link)
             elif wide:

--- a/jobhunter/scraper.py
+++ b/jobhunter/scraper.py
@@ -12,6 +12,57 @@ from jobhunter.constants import SESSION_DIR, TIME_FILTERS
 from jobhunter.ui import console
 
 
+# La UI nueva de busqueda ya no expone el URN del post en el DOM (ni en hrefs
+# ni en atributos); la unica fuente 1:1 es el item "Copiar enlace a la
+# publicacion" del menu de tres puntos, que escribe un lnkd.in al portapapeles.
+# Requiere lanzar el contexto con permissions=["clipboard-read", "clipboard-write"].
+COPY_LINK_JS = r"""async (idx) => {
+    const items = document.querySelectorAll('[role="listitem"]');
+    const item = items[idx];
+    if (!item) return null;
+    item.scrollIntoView({block: 'center'});
+    await new Promise(r => setTimeout(r, 500));
+    const menuBtn = [...item.querySelectorAll('button')]
+        .find(b => /controles|control menu|menú de control/i.test(b.getAttribute('aria-label') || ''));
+    if (!menuBtn) return null;
+    menuBtn.click();
+    await new Promise(r => setTimeout(r, 700));
+    let url = null;
+    try {
+        const opts = [...document.querySelectorAll('[role="menu"] *, .artdeco-dropdown__content *')]
+            .filter(e => /Copiar enlace|Copy link/i.test(e.textContent || '') && e.children.length <= 2);
+        const target = opts.find(e => e.closest('li') || e.tagName === 'BUTTON' || e.getAttribute('role') === 'menuitem') || opts[0];
+        if (target) {
+            target.click();
+            await new Promise(r => setTimeout(r, 800));
+            url = await navigator.clipboard.readText();
+        }
+    } catch (e) {}
+    try { if (menuBtn.getAttribute('aria-expanded') === 'true') menuBtn.click(); } catch (e) {}
+    return url;
+}"""
+
+
+def collect_post_urls(page, count):
+    """Extrae la URL de cada post via el menu "Copiar enlace" (portapapeles).
+
+    Retorna {indice_listitem: url}. Los fallos por item se ignoran (url ausente).
+    """
+    urls = {}
+    for i in range(count):
+        try:
+            url = page.evaluate(COPY_LINK_JS, i)
+        except Exception:
+            continue
+        if isinstance(url, str) and url.strip().startswith("http"):
+            urls[i] = url.strip()
+        try:
+            page.wait_for_timeout(random.randint(200, 500))
+        except Exception:
+            pass
+    return urls
+
+
 def scrape_posts(page, query, max_scroll=4, time_filter="24h"):
     """Busca en LinkedIn por contenido, scrollea y extrae posts con emails."""
     encoded = urllib.parse.quote(query)
@@ -37,31 +88,8 @@ def scrape_posts(page, query, max_scroll=4, time_filter="24h"):
 
     post_urls = {}
     try:
-        listitems = page.locator('[role="listitem"]')
-        for i in range(listitems.count()):
-            try:
-                menu_btn = listitems.nth(i).locator('button[aria-label*="controles"]').first
-                if not menu_btn.is_visible(timeout=500):
-                    continue
-                menu_btn.click()
-                page.wait_for_timeout(random.randint(400, 900))
-                activity_id = page.evaluate(r"""() => {
-                    const links = document.querySelectorAll('a[href*="entityUrn"]');
-                    for (const l of links) {
-                        const m = (l.getAttribute('href') || '').match(/activity%3A(\d+)/);
-                        if (m) return m[1];
-                    }
-                    return null;
-                }""")
-                if activity_id:
-                    post_urls[i] = f"https://www.linkedin.com/feed/update/urn:li:activity:{activity_id}"
-                page.keyboard.press("Escape")
-                page.wait_for_timeout(random.randint(200, 500))
-            except Exception:
-                try:
-                    page.keyboard.press("Escape")
-                except Exception:
-                    pass
+        n_items = page.locator('[role="listitem"]').count()
+        post_urls = collect_post_urls(page, n_items)
     except Exception:
         pass
 

--- a/tests/test_agents_filter.py
+++ b/tests/test_agents_filter.py
@@ -72,5 +72,67 @@ class AgentFilterTests(unittest.TestCase):
         self.assertIn("Espanol", prompt)
 
 
+class LanguageGateTests(unittest.TestCase):
+    def _offer(self, lang):
+        return json.dumps({
+            "is_job": True, "job_title": "Dev", "company": "X",
+            "contact_email": "hr@x.com", "is_relevant": True, "language": lang,
+        })
+
+    @patch("jobhunter.agents.filter.call_gemini")
+    def test_pt_offer_rejected_with_spanish_only_config(self, mock_call):
+        mock_call.return_value = self._offer("pt")
+        cfg = dict(CFG, search_languages="1")
+        result = agent_filter(cfg, "Vaga para desenvolvedor backend hr@x.com")
+        self.assertFalse(result["is_relevant"])
+        self.assertIn("idioma", result["relevance_reason"].lower())
+
+    @patch("jobhunter.agents.filter.call_gemini")
+    def test_es_offer_passes_with_spanish_only_config(self, mock_call):
+        mock_call.return_value = self._offer("es")
+        cfg = dict(CFG, search_languages="1")
+        result = agent_filter(cfg, "Buscamos backend dev hr@x.com")
+        self.assertTrue(result["is_relevant"])
+
+    @patch("jobhunter.agents.filter.call_gemini")
+    def test_en_offer_rejected_when_spanish_only(self, mock_call):
+        mock_call.return_value = self._offer("en")
+        cfg = dict(CFG, search_languages="1")
+        result = agent_filter(cfg, "We are hiring backend dev hr@x.com")
+        self.assertFalse(result["is_relevant"])
+
+    @patch("jobhunter.agents.filter.call_gemini")
+    def test_en_offer_passes_when_bilingual(self, mock_call):
+        mock_call.return_value = self._offer("en")
+        cfg = dict(CFG, search_languages="3")
+        result = agent_filter(cfg, "We are hiring backend dev hr@x.com")
+        self.assertTrue(result["is_relevant"])
+
+    @patch("jobhunter.agents.filter.call_gemini")
+    def test_missing_language_not_blocked(self, mock_call):
+        mock_call.return_value = json.dumps({
+            "is_job": True, "job_title": "Dev", "company": "X",
+            "contact_email": "hr@x.com", "is_relevant": True,
+        })
+        cfg = dict(CFG, search_languages="1")
+        result = agent_filter(cfg, "Buscamos dev hr@x.com")
+        self.assertTrue(result["is_relevant"])
+
+    @patch("jobhunter.agents.filter.call_gemini")
+    def test_regional_variant_normalized(self, mock_call):
+        mock_call.return_value = self._offer("pt-BR")
+        cfg = dict(CFG, search_languages="3")
+        result = agent_filter(cfg, "Vaga backend hr@x.com")
+        self.assertFalse(result["is_relevant"])
+
+    @patch("jobhunter.agents.filter.call_gemini")
+    def test_prompt_mentions_allowed_languages(self, mock_call):
+        mock_call.return_value = json.dumps({"is_job": False})
+        cfg = dict(CFG, search_languages="1")
+        agent_filter(cfg, "post")
+        prompt = mock_call.call_args.args[1]
+        self.assertIn("espanol (es)", prompt.lower())
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -63,6 +63,28 @@ class FakePage:
         return self.main_text
 
 
+class CollectPostUrlsTests(unittest.TestCase):
+    def test_collects_only_valid_urls(self):
+        from jobhunter.scraper import collect_post_urls
+        page = MagicMock()
+        page.evaluate.side_effect = ["https://lnkd.in/p/abc", None, "not-a-url"]
+        urls = collect_post_urls(page, 3)
+        self.assertEqual(urls, {0: "https://lnkd.in/p/abc"})
+
+    def test_survives_evaluate_errors(self):
+        from jobhunter.scraper import collect_post_urls
+        page = MagicMock()
+        page.evaluate.side_effect = [RuntimeError("boom"), "https://lnkd.in/p/xyz"]
+        urls = collect_post_urls(page, 2)
+        self.assertEqual(urls, {1: "https://lnkd.in/p/xyz"})
+
+    def test_zero_items(self):
+        from jobhunter.scraper import collect_post_urls
+        page = MagicMock()
+        self.assertEqual(collect_post_urls(page, 0), {})
+        page.evaluate.assert_not_called()
+
+
 class ExtractPostTextTests(unittest.TestCase):
     def test_prefers_expandable_text_box(self):
         from jobhunter.scraper import extract_post_text


### PR DESCRIPTION
## Bug 1: links de posts en cero desde el 27-jul

Evidencia en logs: 6-jul 22/36 posts con URL; 27-jul y 3-ago **0/92**. LinkedIn elimino el URN del DOM (sin atributos data-urn, sin hrefs con entityUrn, 0 menciones en el HTML hidratado). La unica fuente 1:1 restante es "Copiar enlace a la publicacion" del menu de tres puntos.

Fix: `collect_post_urls` abre el menu por item (scrollIntoView para la lista virtualizada), pulsa copiar y lee `navigator.clipboard` (contexto con permisos de clipboard). La tabla muestra la URL `lnkd.in/p/...` visible en terminales anchas. Smoke real: **6/6 posts con URL**.

## Bug 2: aplicaba a ofertas en portugues

La regla del prompt solo descartaba idiomas REQUERIDOS explicitamente; un post brasileno no "requiere" portugues y Gemini lo dejaba pasar (5/19 aceptadas el 3-ago eran pt). Fix en dos capas: regla nueva en el prompt + gate deterministico `enforce_language_gate` sobre el `language` detectado, con idiomas permitidos derivados de `search_languages` (es/en segun config). En `apply` el usuario puede seguir forzando (el gate solo marca no relevante).

## Tests

176 en verde (10 nuevos: 7 de gate de idioma, 3 de collect_post_urls).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbiZFrFNvVvCimgaapzY81