### PR TITLE
feat: red asistida de reclutadores, validacion MX pre-envio y analitica por query

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ jobhunter optimize "feedback"        # Optimization with custom context
 jobhunter apply [link|"texto"]       # Apply to a single posting (paste mode if no arg, sentinel ".")
 jobhunter dashboard [--port N]       # Local metrics dashboard (default 4090)
 jobhunter sync [--days N]            # Reconcile replies/bounces via Gmail IMAP (default 60)
+jobhunter network                    # Assisted recruiter connections (opens profiles, user clicks)
 jobhunter history                    # Application history (--last N, --company, --since, --all)
 jobhunter blacklist                  # View/add/remove blocked companies
 jobhunter status                     # Config & stats dashboard
@@ -63,7 +64,7 @@ All agents call Gemini via direct HTTP POST (`call_gemini()` / `call_gemini_visi
   - `metrics.py` — agregados puros para el dashboard
   - `inbox.py` — lectura IMAP + conciliacion de respuestas/rebotes
   - `assets/dashboard.html` — pagina autocontenida del dashboard
-  - `cli/apply.py`, `cli/dashboard.py`, `cli/sync.py` — comandos nuevos
+  - `cli/apply.py`, `cli/dashboard.py`, `cli/sync.py`, `cli/network.py` — comandos nuevos
   - `cli/main.py` — dispatcher + parse_time_filter
   - `cli/setup.py` + los demas `cli/*.py` — comandos CLI individuales
   - `cv/builder.py` + `cv/templates/` — generacion de CV PDF

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ jobhunter apply [link|"texto"]           Aplicar a una publicacion puntual
 jobhunter apply                          Modo pegar texto (termina con '.')
 jobhunter dashboard                      Dashboard local de historial y metricas
 jobhunter sync                           Conciliar respuestas y rebotes (Gmail IMAP)
+jobhunter network                        Conectar con reclutadores ya contactados
 jobhunter history                        Historial de aplicaciones enviadas
 jobhunter blacklist                      Ver empresas bloqueadas
 jobhunter blacklist add "Empresa"        Bloquear empresa

--- a/bin/jobhunter.cmd
+++ b/bin/jobhunter.cmd
@@ -1,0 +1,2 @@
+@echo off
+python "C:\Users\joseg\.jobhunter\job.py" %*

--- a/bin/jobhunter.ps1
+++ b/bin/jobhunter.ps1
@@ -1,0 +1,1 @@
+& python "C:\Users\joseg\.jobhunter\job.py" @args

--- a/docs/superpowers/plans/2026-08-05-network-mx-analytics.md
+++ b/docs/superpowers/plans/2026-08-05-network-mx-analytics.md
@@ -1,0 +1,48 @@
+# network + MX check + query analytics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans (same-session inline execution). Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Assisted recruiter-network command, DNS MX validation before sending, and per-query reply analytics feeding `optimize`, per `docs/superpowers/specs/2026-08-05-network-mx-analytics-design.md`.
+
+**Architecture:** Author + query tags captured at scrape time flow through offers into `kb.applications`. `network` reads those tags and tracks state in `kb["network"]` (no LinkedIn automation; opens default browser). MX check is a raw stdlib UDP DNS query in `mailer.py`, enforced in `applying.apply_to_offer`. `optimizer.py` gains a pure `build_query_stats` injected into its prompt.
+
+**Tech Stack:** Python 3.10+ stdlib only (socket, struct, webbrowser). unittest.
+
+## Global Constraints
+
+Same as the 2026-08-05 apply/dashboard/sync plan: repo root `C:\Users\joseg\.jobhunter`, Spanish CLI text without emojis, no nested-quote/triple-quoted f-strings, tests never touch real config/kb, Spanish conventional commits on `feature/network-mx-analytics` with the session trailer.
+
+### Task 1: DNS MX check in `mailer.py` + gate in `applying.py`
+
+- Test: `tests/test_mailer.py` append `DomainAcceptsMailTests` — `_build_mx_query` ends with qtype 15/class 1; `_parse_mx_response`: an>0 → True, rcode 3 → False, rcode 0 an=0 → False, wrong txid → None, short → None; bad email ("", "sin-arroba") → False without network.
+- Implement `_build_mx_query(domain, txid)`, `_parse_mx_response(data, txid)`, `domain_accepts_mail(email, resolver=("8.8.8.8", 53), timeout=3.0)` (any exception → None).
+- Test: `tests/test_applying.py` — patch `jobhunter.applying.domain_accepts_mail`: existing send tests patched to True; new: False+interactive → Prompt alt email used as recipient and persisted; False+interactive+empty alt → skipped; False+non-interactive → skipped; None → sends. Skip check entirely when `test_email` is set.
+- Implement gate in `apply_to_offer` after the `if not do_send` block, before SMTP.
+- Live smoke: `domain_accepts_mail` on `nubelity.com` (True) vs `nuvelity.com` (expected False) vs `gmail.com` (True).
+- Commit: `feat(mailer): validacion MX del dominio antes de enviar`.
+
+### Task 2: query + author tags end-to-end
+
+- Scraper: posts-extraction JS adds `author_url` (first `a[href*="/in/"]` in the closest listitem, no query params) and `author_name` (anchor text first line).
+- Pipeline: tag `pi["query"] = query` in the Phase 1 dedup loop; Phase 2 accepted offers copy `query`, `author_url`, `author_name` from the post.
+- `applying.apply_to_offer`: kb record gains `query`, `author_url`, `author_name` (None for manual `apply`).
+- Test: `tests/test_applying.py` sent test asserts the three fields persist from the job dict.
+- Commit: `feat(pipeline): etiquetar query y autor del post hasta el historial`.
+
+### Task 3: `build_query_stats` + optimizer injection
+
+- Test: `tests/test_agents_optimizer.py` append — stats string contains query with sent/replied counts sorted by replies; empty when no tagged apps; prompt includes `RENDIMIENTO REAL POR QUERY` when kb has tagged apps (patch `call_gemini`, inspect prompt) and omits it otherwise.
+- Implement `build_query_stats(applications, top=15)` in `agents/optimizer.py`; inject into the prompt next to `run_stats` with the keep/drop instruction.
+- Commit: `feat(optimize): rendimiento real por query en el prompt`.
+
+### Task 4: `jobhunter network` command
+
+- Test: `tests/test_cli_network.py` — `build_network_queue` dedups by profile vs `kb["network"]` and within itself, skips apps without `author_url`, newest first; `cmd_network` flow with mocked Prompt/Confirm/webbrowser/save_kb: open+confirm → entry `invited`, `x` → `skipped`, `q` → stops; empty queue prints the explanation that authors are captured from now on.
+- Implement `jobhunter/cli/network.py` (`build_network_queue`, `cmd_network`), wire dispatcher `network` + help rows + guardrail note (~100 invites/week cap is LinkedIn-wide; keep manual pace moderate).
+- Commit: `feat(network): cola asistida de reclutadores para conectar`.
+
+### Task 5: docs + finish
+
+- README + CLAUDE.md command lists; full suite; py_compile new files; grep for forbidden f-string patterns.
+- Commit: `docs: documentar network, validacion MX y analitica por query`.
+- finishing-a-development-branch: push, PR, CI, ask merge.

--- a/docs/superpowers/specs/2026-08-05-network-mx-analytics-design.md
+++ b/docs/superpowers/specs/2026-08-05-network-mx-analytics-design.md
@@ -1,0 +1,78 @@
+# Design: assisted recruiter network, MX pre-send check, per-query analytics
+
+Date: 2026-08-05
+Status: approved by user (selected from proposed options, conversation 2026-08-05)
+
+## Context
+
+Three improvements selected by the user after the apply/dashboard/sync release:
+
+1. Grow the LinkedIn network with recruiters so searches surface more posts —
+   **assisted mode** (full automation of invites is a top ban vector; a ban
+   would also kill the scraping session).
+2. Two recent bounces were caused by a typo'd domain (`nuvelity.com` instead
+   of `nubelity.com`). Validate the recipient domain before sending.
+3. `optimize` has no signal about which queries produce offers that get
+   replies. Feed reconciliation results back per query.
+
+## Feature A: author capture + `jobhunter network` (assisted)
+
+- During scraping, capture the post author per listitem: first anchor matching
+  `a[href*="/in/"]` gives `author_url` (path only, no query params) and
+  `author_name` (anchor text, first line). Stored on each post; carried onto
+  offers (`author_url`, `author_name`) and into `kb.applications` records.
+- New command `jobhunter network`:
+  - Builds a queue of recruiter candidates from `kb.applications` (newest
+    first): entries with `author_url`, deduped, excluding profiles already in
+    `kb["network"]`.
+  - Interactive loop per candidate: shows name, company, job title, applied
+    date; options `(a)` open profile in the DEFAULT browser (`webbrowser` —
+    the user's logged-in browser, where they click "Conectar" themselves),
+    `(x)` skip, `(q)` quit. After opening, asks if the invite was sent.
+  - Persists to `kb["network"]`: `{profile_url, name, company, status:
+    "invited"|"skipped", date}`. Never auto-clicks anything on LinkedIn.
+  - Prints a guardrail note: keep manual invites moderate (LinkedIn caps
+    ~100/week for everyone).
+
+## Feature B: MX validation before sending
+
+- `jobhunter/mailer.py` gains `domain_accepts_mail(email) -> True|False|None`:
+  - Minimal DNS MX query over UDP (stdlib socket, no new deps, no
+    locale-dependent `nslookup` parsing): question type MX (15) to the public
+    resolver `8.8.8.8:53`, 3s timeout.
+  - `True` = answer count > 0; `False` = NOERROR/NXDOMAIN with zero MX
+    answers; `None` = network error/timeout (unknown, never blocks).
+- `applying.apply_to_offer` checks before sending (only when result is
+  `False`):
+  - Interactive: warn `El dominio X no tiene registros de correo (posible
+    typo)` and prompt for an alternative email (empty = skip this offer).
+  - Non-interactive (`--auto`): skip the offer, counted as skipped with the
+    reason printed.
+- Existing tests that reach the send path mock `domain_accepts_mail`.
+
+## Feature C: per-query analytics feeding optimize
+
+- Pipeline tags each scraped post with the `query` that found it; the tag
+  flows to the offer and into the `kb.applications` record (field `query`).
+  `apply` records have no query (manual).
+- `agents/optimizer.py` builds a per-query performance block from
+  `kb.applications` (only entries having `query`): sent count and replied
+  count per query, sorted by replies then sent, top 15. Injected into the
+  prompt as `RENDIMIENTO REAL POR QUERY` with an instruction to keep/expand
+  patterns from queries that got replies and drop patterns with sends but no
+  replies. Omitted when no tagged data exists yet.
+
+## Out of scope
+
+- Automated connection requests or invite notes (ban risk).
+- Follow-up emails (not selected).
+- Dashboard rendering of network/query data (can come later).
+
+## Tests
+
+unittest, existing style: DNS packet build/parse with crafted bytes; author
+extraction via fake page; network queue building + dedup vs kb["network"]
+(command loop with mocked Prompt/webbrowser); query tag propagation into kb
+record via `apply_to_offer`; optimizer prompt includes per-query block when
+data exists and omits it when not; MX gate paths in `apply_to_offer`
+(interactive alternate email / non-interactive skip / None never blocks).

--- a/jobhunter/agents/optimizer.py
+++ b/jobhunter/agents/optimizer.py
@@ -5,6 +5,35 @@ import json
 from jobhunter.ai.gemini import call_gemini
 
 
+def build_query_stats(applications, top=15):
+    """Bloque de rendimiento por query (enviados/respuestas) para el prompt.
+
+    Solo considera aplicaciones etiquetadas con query (las nuevas); retorna
+    cadena vacia si no hay datos aun.
+    """
+    stats = {}
+    for a in applications or []:
+        q = a.get("query")
+        if not q:
+            continue
+        s = stats.setdefault(q, {"sent": 0, "replied": 0})
+        s["sent"] += 1
+        if a.get("status") == "replied":
+            s["replied"] += 1
+    if not stats:
+        return ""
+    rows = sorted(stats.items(), key=lambda kv: (-kv[1]["replied"], -kv[1]["sent"]))[:top]
+    lines = [
+        '- "' + q + '": ' + str(v["sent"]) + " enviados, " + str(v["replied"]) + " respuestas"
+        for q, v in rows
+    ]
+    return (
+        "\nRENDIMIENTO REAL POR QUERY (aplicaciones enviadas y respuestas de reclutadores):\n"
+        + "\n".join(lines)
+        + "\n- Conserva y expande los patrones de las queries CON respuestas; descarta o reformula los patrones con envios y cero respuestas."
+    )
+
+
 def optimize_queries(cfg, kb, user_prompt=None):
     """Genera queries optimizadas a partir del perfil, queries actuales y metricas de historial.
 
@@ -44,6 +73,8 @@ def optimize_queries(cfg, kb, user_prompt=None):
         titles = list(set(a.get("job_title", "") for a in apps[-30:]))
         applied_titles = f"\nPUESTOS A LOS QUE YA APLICO (ultimos 30): {', '.join(titles[:15])}"
 
+    query_stats = build_query_stats(apps)
+
     user_context = ""
     if user_prompt:
         user_context = (
@@ -74,6 +105,7 @@ CONTEXTO DEL CANDIDATO:
 QUERIES ACTUALES ({len(current_queries)}):
 {queries_json}
 {run_stats}
+{query_stats}
 {applied_titles}
 {user_context}
 

--- a/jobhunter/applying.py
+++ b/jobhunter/applying.py
@@ -14,7 +14,7 @@ from jobhunter.agents.cv import agent_cv
 from jobhunter.agents.email import agent_email
 from jobhunter.constants import BASE_DIR
 from jobhunter.cv.builder import generate_cv_pdf, get_cv_filename
-from jobhunter.mailer import send_email
+from jobhunter.mailer import domain_accepts_mail, send_email
 from jobhunter.ui import console
 
 
@@ -135,6 +135,24 @@ def apply_to_offer(cfg, kb, job, test_email=None, dry_run=False,
         record["skipped"] = True
         return {"status": "skipped", "record": record, "preview_send_all": preview_send_all}
 
+    if not test_email and domain_accepts_mail(to) is False:
+        console.print(f"{label}  [yellow]![/yellow] El dominio de [bold]{to}[/bold] no tiene registros de correo (posible typo)")
+        if interactive:
+            alt = (Prompt.ask("  Email alternativo (vacio = omitir esta oferta)", default="") or "").strip()
+            if alt and "@" in alt:
+                to = alt
+                rec_email = alt
+                record["sent_to"] = to
+                record["recruiter_email"] = rec_email
+            else:
+                console.print("       [yellow]·[/yellow] Omitido por dominio invalido")
+                record["skipped"] = True
+                return {"status": "skipped", "record": record, "preview_send_all": preview_send_all}
+        else:
+            console.print("       [yellow]·[/yellow] Omitido por dominio invalido")
+            record["skipped"] = True
+            return {"status": "skipped", "record": record, "preview_send_all": preview_send_all}
+
     try:
         send_email(cfg, to, edata["subject"], body, cv_path)
         console.print(f"{label}  [green]> Enviado[/green] [dim]→ {to}[/dim]")
@@ -147,6 +165,9 @@ def apply_to_offer(cfg, kb, job, test_email=None, dry_run=False,
             "mode": mode,
             "post_url": job.get("post_url"),
             "subject": edata["subject"],
+            "query": job.get("query"),
+            "author_url": job.get("author_url"),
+            "author_name": job.get("author_name"),
         })
         return {"status": "sent", "record": record, "preview_send_all": preview_send_all}
     except Exception as e:

--- a/jobhunter/cli/help.py
+++ b/jobhunter/cli/help.py
@@ -22,6 +22,7 @@ def cmd_help():
     cmds.add_row("jobhunter apply [link|texto]", "Aplicar a una publicacion puntual")
     cmds.add_row("jobhunter dashboard", "Dashboard local de historial y metricas")
     cmds.add_row("jobhunter sync", "Conciliar respuestas y rebotes (Gmail IMAP)")
+    cmds.add_row("jobhunter network", "Conectar con reclutadores ya contactados")
     cmds.add_row("jobhunter history", "Historial de aplicaciones")
     cmds.add_row("jobhunter blacklist", "Ver/agregar/quitar empresas bloqueadas")
     cmds.add_row("jobhunter status", "Ver configuracion y estadisticas")

--- a/jobhunter/cli/main.py
+++ b/jobhunter/cli/main.py
@@ -6,6 +6,7 @@ from jobhunter.banner import get_banner
 from jobhunter.cli.apply import cmd_apply
 from jobhunter.cli.blacklist import cmd_blacklist
 from jobhunter.cli.dashboard import cmd_dashboard
+from jobhunter.cli.network import cmd_network
 from jobhunter.cli.sync import cmd_sync
 from jobhunter.cli.help import cmd_help
 from jobhunter.cli.login import cmd_login
@@ -106,6 +107,8 @@ def main():
                 except ValueError:
                     pass
         cmd_sync(days=days)
+    elif cmd in ("network",):
+        cmd_network()
     elif cmd in ("status",):
         cmd_status()
     elif cmd in ("update",):

--- a/jobhunter/cli/network.py
+++ b/jobhunter/cli/network.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+"""Comando network: cola asistida de reclutadores para ampliar la red.
+
+Nunca automatiza acciones en LinkedIn: abre el perfil en el navegador por
+defecto (donde el usuario tiene su sesion normal) y es el usuario quien da
+clic en Conectar. Solo se lleva el registro en kb["network"].
+"""
+import webbrowser
+from datetime import datetime
+
+from rich.panel import Panel
+from rich.prompt import Confirm, Prompt
+
+from jobhunter.banner import get_banner
+from jobhunter.storage import load_kb, save_kb
+from jobhunter.ui import console
+
+
+def build_network_queue(applications, network):
+    """Candidatos a conectar: autores de posts aplicados, sin repetir ni re-ofrecer."""
+    seen = {n.get("profile_url") for n in (network or [])}
+    queue = []
+    ordered = sorted(applications or [], key=lambda x: x.get("date") or "", reverse=True)
+    for a in ordered:
+        url = a.get("author_url")
+        if not url or url in seen:
+            continue
+        seen.add(url)
+        queue.append({
+            "profile_url": url,
+            "name": a.get("author_name") or "?",
+            "company": a.get("company") or "-",
+            "job_title": a.get("job_title") or "-",
+            "applied": (a.get("date") or "")[:10],
+        })
+    return queue
+
+
+def cmd_network():
+    kb = load_kb()
+    console.print(get_banner())
+
+    queue = build_network_queue(kb.get("applications", []), kb.get("network", []))
+    if not queue:
+        console.print("  [yellow]![/yellow] Sin candidatos por ahora.")
+        console.print("    [dim]Los autores de los posts se capturan desde ahora en cada run/apply;[/dim]")
+        console.print("    [dim]despues de tu proximo run tendras reclutadores aqui.[/dim]")
+        return
+
+    console.print(f"  [bold]{len(queue)}[/bold] reclutadores a los que ya aplicaste y aun no conectas")
+    console.print("  [dim]Se abre el perfil en TU navegador y tu decides dar clic en Conectar.[/dim]")
+    console.print("  [dim]Modera el ritmo: LinkedIn limita ~100 invitaciones/semana para todos.[/dim]")
+    console.print()
+
+    network = kb.setdefault("network", [])
+    invited = 0
+    for cand in queue:
+        console.print(Panel(
+            f"  [bold]{cand['name']}[/bold]\n"
+            f"  [dim]Aplicaste a[/dim]  {cand['job_title']} [dim]en[/dim] {cand['company']} [dim]({cand['applied']})[/dim]\n"
+            f"  [cyan]{cand['profile_url']}[/cyan]",
+            border_style="cyan",
+        ))
+        choice = Prompt.ask("  (a) Abrir perfil  (x) Saltar  (q) Salir", default="a").strip().lower()
+        if choice in ("q", "quit"):
+            break
+        entry = {
+            "profile_url": cand["profile_url"],
+            "name": cand["name"],
+            "company": cand["company"],
+            "date": datetime.now().isoformat(),
+        }
+        if choice in ("a", "abrir", ""):
+            webbrowser.open(cand["profile_url"])
+            sent = Confirm.ask("  Enviaste la invitacion?", default=True)
+            entry["status"] = "invited" if sent else "skipped"
+            if sent:
+                invited += 1
+        else:
+            entry["status"] = "skipped"
+        network.append(entry)
+        console.print()
+
+    save_kb(kb)
+    console.print(f"  [green]✓[/green] {invited} invitaciones registradas  [dim]({len(network)} perfiles gestionados en total)[/dim]")

--- a/jobhunter/mailer.py
+++ b/jobhunter/mailer.py
@@ -1,10 +1,59 @@
-"""Envio de correos via Gmail SMTP con retry."""
+"""Envio de correos via Gmail SMTP con retry, y chequeo MX del destinatario."""
 import os
+import random
 import smtplib
+import socket
+import struct
 import time
 from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
+
+# Consulta DNS MX cruda por UDP (stdlib): nslookup tiene salida localizada y
+# dnspython seria una dependencia nueva. Solo se necesita saber si hay
+# respuestas MX, no leerlas.
+DNS_RESOLVER = ("8.8.8.8", 53)
+
+
+def _build_mx_query(domain, txid):
+    header = struct.pack(">HHHHHH", txid, 0x0100, 1, 0, 0, 0)
+    qname = b"".join(bytes([len(p)]) + p.encode("idna") for p in domain.split("."))
+    return header + qname + b"\x00" + struct.pack(">HH", 15, 1)
+
+
+def _parse_mx_response(data, txid):
+    if not data or len(data) < 12:
+        return None
+    rid, flags, _qd, ancount, _ns, _ar = struct.unpack(">HHHHHH", data[:12])
+    if rid != txid:
+        return None
+    rcode = flags & 0xF
+    if rcode == 3:
+        return False
+    if rcode != 0:
+        return None
+    return ancount > 0
+
+
+def domain_accepts_mail(email, resolver=DNS_RESOLVER, timeout=3.0):
+    """True si el dominio del email tiene MX, False si no existe/no recibe correo,
+    None si no se pudo verificar (nunca debe bloquear el envio)."""
+    domain = (email or "").rsplit("@", 1)[-1].strip().lower().rstrip(".")
+    if "@" not in (email or "") or not domain or "." not in domain:
+        return False
+    try:
+        txid = random.randint(0, 0xFFFF)
+        pkt = _build_mx_query(domain, txid)
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        s.settimeout(timeout)
+        try:
+            s.sendto(pkt, resolver)
+            data, _ = s.recvfrom(2048)
+        finally:
+            s.close()
+        return _parse_mx_response(data, txid)
+    except Exception:
+        return None
 
 
 def send_email(cfg, to, subject, body, cv_path=None, max_retries=3):

--- a/jobhunter/pipeline.py
+++ b/jobhunter/pipeline.py
@@ -111,6 +111,7 @@ def cmd_run(
                         key = pi["text"][:150]
                         if key not in seen:
                             seen.add(key)
+                            pi["query"] = query
                             all_posts.append(pi)
                     total_emails_found = sum(len(p.get("emails_found",[])) for p in all_posts)
                     prog.advance(task)
@@ -202,6 +203,9 @@ def cmd_run(
                 a["job_title"] = a.get("job_title") or "Software Developer"
                 a["company"] = a.get("company") or "Empresa"
                 a["post_url"] = post.get("post_url")
+                a["query"] = post.get("query")
+                a["author_url"] = post.get("author_url")
+                a["author_name"] = post.get("author_name")
                 offers.append(a)
             prog.advance(task)
             time.sleep(1.5)

--- a/jobhunter/scraper.py
+++ b/jobhunter/scraper.py
@@ -103,7 +103,17 @@ def scrape_posts(page, query, max_scroll=4, time_filter="24h"):
             if (seen.has(key)) return;
             seen.add(key);
             const emails = [...new Set((text.match(/[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}/g) || []))];
-            posts.push({text: text.substring(0, 4000), emails_found: emails, index: idx});
+            let author_url = null, author_name = null;
+            const item = box.closest('[role="listitem"]');
+            if (item) {
+                const a = item.querySelector('a[href*="/in/"]');
+                if (a) {
+                    author_url = (a.href || '').split('?')[0] || null;
+                    author_name = ((a.innerText || '').split('\n')[0] || '').trim() || null;
+                }
+            }
+            posts.push({text: text.substring(0, 4000), emails_found: emails, index: idx,
+                        author_url, author_name});
         });
         return posts;
     }""")

--- a/tests/test_agents_optimizer.py
+++ b/tests/test_agents_optimizer.py
@@ -72,5 +72,44 @@ class OptimizerTests(unittest.TestCase):
         self.assertNotIn("HISTORIAL", prompt)
 
 
+class QueryStatsTests(unittest.TestCase):
+    def _apps(self):
+        return [
+            {"query": "Vacante IA remoto", "status": "replied"},
+            {"query": "Vacante IA remoto", "status": "no_reply"},
+            {"query": "Backend remoto CV", "status": "no_reply"},
+            {"query": None, "status": "replied"},
+            {"status": "replied"},
+        ]
+
+    def test_stats_sorted_by_replies(self):
+        from jobhunter.agents.optimizer import build_query_stats
+        block = build_query_stats(self._apps())
+        self.assertIn("RENDIMIENTO REAL POR QUERY", block)
+        self.assertIn("Vacante IA remoto", block)
+        self.assertIn("2 enviados, 1 respuestas", block)
+        self.assertLess(block.index("Vacante IA remoto"), block.index("Backend remoto CV"))
+
+    def test_empty_when_no_tagged_apps(self):
+        from jobhunter.agents.optimizer import build_query_stats
+        self.assertEqual(build_query_stats([{"status": "replied"}]), "")
+        self.assertEqual(build_query_stats([]), "")
+
+    @patch("jobhunter.agents.optimizer.call_gemini")
+    def test_prompt_includes_query_stats_when_available(self, mock_call):
+        mock_call.return_value = json.dumps({"queries": []})
+        kb = {"runs": [], "applications": self._apps()}
+        optimize_queries(CFG, kb)
+        prompt = mock_call.call_args.args[1]
+        self.assertIn("RENDIMIENTO REAL POR QUERY", prompt)
+
+    @patch("jobhunter.agents.optimizer.call_gemini")
+    def test_prompt_omits_query_stats_without_data(self, mock_call):
+        mock_call.return_value = json.dumps({"queries": []})
+        optimize_queries(CFG, {"runs": [], "applications": []})
+        prompt = mock_call.call_args.args[1]
+        self.assertNotIn("RENDIMIENTO REAL POR QUERY", prompt)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_applying.py
+++ b/tests/test_applying.py
@@ -20,15 +20,17 @@ def _job():
 
 
 class ApplyToOfferTests(unittest.TestCase):
+    @patch("jobhunter.applying.domain_accepts_mail", return_value=True)
     @patch("jobhunter.applying.console")
     @patch("jobhunter.applying.send_email")
     @patch("jobhunter.applying.agent_email", return_value={"subject": "Asunto X", "body": "Cuerpo"})
     @patch("jobhunter.applying.generate_cv_pdf")
     @patch("jobhunter.applying.get_cv_filename", return_value="cv.pdf")
     @patch("jobhunter.applying.agent_cv", return_value={"title": "cv"})
-    def test_sent_appends_to_kb_with_subject_and_mode(self, _cv, _fn, _pdf, _em, mock_send, _c):
+    def test_sent_appends_to_kb_with_subject_and_mode(self, _cv, _fn, _pdf, _em, mock_send, _c, _mx):
         kb = {"applications": []}
-        res = apply_to_offer(_cfg(), kb, _job(), interactive=False, mode="manual")
+        job = dict(_job(), query="Vacante AI remoto", author_url="https://linkedin.com/in/rec", author_name="Reclutadora X")
+        res = apply_to_offer(_cfg(), kb, job, interactive=False, mode="manual")
         self.assertEqual(res["status"], "sent")
         mock_send.assert_called_once()
         self.assertEqual(len(kb["applications"]), 1)
@@ -37,6 +39,9 @@ class ApplyToOfferTests(unittest.TestCase):
         self.assertEqual(app["subject"], "Asunto X")
         self.assertEqual(app["recruiter_email"], "hr@acme.com")
         self.assertEqual(app["sent_to"], "hr@acme.com")
+        self.assertEqual(app["query"], "Vacante AI remoto")
+        self.assertEqual(app["author_url"], "https://linkedin.com/in/rec")
+        self.assertEqual(app["author_name"], "Reclutadora X")
 
     @patch("jobhunter.applying.console")
     @patch("jobhunter.applying.send_email")
@@ -74,6 +79,91 @@ class ApplyToOfferTests(unittest.TestCase):
         args = mock_send.call_args.args
         self.assertEqual(args[1], "yo@test.com")
         self.assertEqual(kb["applications"][0]["sent_to"], "yo@test.com")
+
+
+class MxGateTests(unittest.TestCase):
+    def _patches(self):
+        return [
+            patch("jobhunter.applying.console"),
+            patch("jobhunter.applying.send_email"),
+            patch("jobhunter.applying.agent_email", return_value={"subject": "S", "body": "B"}),
+            patch("jobhunter.applying.generate_cv_pdf"),
+            patch("jobhunter.applying.get_cv_filename", return_value="cv.pdf"),
+            patch("jobhunter.applying.agent_cv", return_value={}),
+        ]
+
+    def _run(self, mx_value, prompt_answer=None, interactive=False):
+        kb = {"applications": []}
+        ps = self._patches()
+        mocks = [p.start() for p in ps]
+        try:
+            with patch("jobhunter.applying.domain_accepts_mail", return_value=mx_value):
+                if interactive:
+                    with patch("jobhunter.applying.Prompt") as mock_prompt:
+                        mock_prompt.ask.return_value = prompt_answer if prompt_answer is not None else "s"
+                        res = apply_to_offer(_cfg(), kb, _job(), interactive=True)
+                else:
+                    res = apply_to_offer(_cfg(), kb, _job(), interactive=False)
+        finally:
+            for p in ps:
+                p.stop()
+        return res, kb, mocks[1]
+
+    def test_mx_false_non_interactive_skips(self):
+        res, kb, mock_send = self._run(False)
+        self.assertEqual(res["status"], "skipped")
+        mock_send.assert_not_called()
+        self.assertEqual(kb["applications"], [])
+
+    def test_mx_none_does_not_block(self):
+        res, kb, mock_send = self._run(None)
+        self.assertEqual(res["status"], "sent")
+        mock_send.assert_called_once()
+
+    def test_mx_false_interactive_alternate_email(self):
+        kb = {"applications": []}
+        ps = self._patches()
+        mocks = [p.start() for p in ps]
+        try:
+            with patch("jobhunter.applying.domain_accepts_mail", return_value=False):
+                with patch("jobhunter.applying.Prompt") as mock_prompt:
+                    mock_prompt.ask.side_effect = ["s", "hr@acme-corp.com"]
+                    res = apply_to_offer(_cfg(), kb, _job(), interactive=True)
+        finally:
+            for p in ps:
+                p.stop()
+        self.assertEqual(res["status"], "sent")
+        self.assertEqual(mocks[1].call_args.args[1], "hr@acme-corp.com")
+        self.assertEqual(kb["applications"][0]["sent_to"], "hr@acme-corp.com")
+        self.assertEqual(kb["applications"][0]["recruiter_email"], "hr@acme-corp.com")
+
+    def test_mx_false_interactive_empty_alt_skips(self):
+        kb = {"applications": []}
+        ps = self._patches()
+        mocks = [p.start() for p in ps]
+        try:
+            with patch("jobhunter.applying.domain_accepts_mail", return_value=False):
+                with patch("jobhunter.applying.Prompt") as mock_prompt:
+                    mock_prompt.ask.side_effect = ["s", ""]
+                    res = apply_to_offer(_cfg(), kb, _job(), interactive=True)
+        finally:
+            for p in ps:
+                p.stop()
+        self.assertEqual(res["status"], "skipped")
+        mocks[1].assert_not_called()
+
+    def test_mx_not_checked_in_test_mode(self):
+        kb = {"applications": []}
+        ps = self._patches()
+        [p.start() for p in ps]
+        try:
+            with patch("jobhunter.applying.domain_accepts_mail") as mock_mx:
+                res = apply_to_offer(_cfg(), kb, _job(), test_email="yo@test.com", interactive=False, mode="test")
+        finally:
+            for p in ps:
+                p.stop()
+        self.assertEqual(res["status"], "sent")
+        mock_mx.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_cli_network.py
+++ b/tests/test_cli_network.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+import unittest
+from unittest.mock import patch
+
+from jobhunter.cli.network import build_network_queue, cmd_network
+
+
+def _app(url, name="Rec", date="2026-08-01T10:00:00", company="Acme", title="Dev"):
+    return {"author_url": url, "author_name": name, "date": date,
+            "company": company, "job_title": title}
+
+
+class BuildNetworkQueueTests(unittest.TestCase):
+    def test_dedups_and_excludes_existing(self):
+        apps = [
+            _app("https://linkedin.com/in/ana", date="2026-08-03T10:00:00"),
+            _app("https://linkedin.com/in/ana", date="2026-08-01T10:00:00"),
+            _app("https://linkedin.com/in/luis", date="2026-08-02T10:00:00"),
+            _app("https://linkedin.com/in/eva", date="2026-08-04T10:00:00"),
+            {"date": "2026-08-05T10:00:00", "company": "SinAutor", "job_title": "X"},
+        ]
+        network = [{"profile_url": "https://linkedin.com/in/eva", "status": "invited"}]
+        queue = build_network_queue(apps, network)
+        self.assertEqual([q["profile_url"] for q in queue],
+                         ["https://linkedin.com/in/ana", "https://linkedin.com/in/luis"])
+
+    def test_empty_inputs(self):
+        self.assertEqual(build_network_queue([], []), [])
+        self.assertEqual(build_network_queue(None, None), [])
+
+
+class CmdNetworkTests(unittest.TestCase):
+    @patch("jobhunter.cli.network.console")
+    @patch("jobhunter.cli.network.save_kb")
+    @patch("jobhunter.cli.network.webbrowser")
+    @patch("jobhunter.cli.network.Confirm")
+    @patch("jobhunter.cli.network.Prompt")
+    @patch("jobhunter.cli.network.load_kb")
+    def test_open_confirm_then_quit(self, mock_lk, mock_prompt, mock_confirm, mock_wb, mock_save, _c):
+        kb = {"applications": [
+            _app("https://linkedin.com/in/ana"),
+            _app("https://linkedin.com/in/luis"),
+        ], "network": []}
+        mock_lk.return_value = kb
+        mock_prompt.ask.side_effect = ["a", "q"]
+        mock_confirm.ask.return_value = True
+        cmd_network()
+        mock_wb.open.assert_called_once_with("https://linkedin.com/in/ana")
+        self.assertEqual(len(kb["network"]), 1)
+        self.assertEqual(kb["network"][0]["status"], "invited")
+        mock_save.assert_called_once_with(kb)
+
+    @patch("jobhunter.cli.network.console")
+    @patch("jobhunter.cli.network.save_kb")
+    @patch("jobhunter.cli.network.webbrowser")
+    @patch("jobhunter.cli.network.Prompt")
+    @patch("jobhunter.cli.network.load_kb")
+    def test_skip_records_skipped(self, mock_lk, mock_prompt, mock_wb, mock_save, _c):
+        kb = {"applications": [_app("https://linkedin.com/in/ana")], "network": []}
+        mock_lk.return_value = kb
+        mock_prompt.ask.side_effect = ["x"]
+        cmd_network()
+        mock_wb.open.assert_not_called()
+        self.assertEqual(kb["network"][0]["status"], "skipped")
+
+    @patch("jobhunter.cli.network.console")
+    @patch("jobhunter.cli.network.load_kb", return_value={"applications": [], "network": []})
+    def test_empty_queue_explains(self, _lk, mock_console):
+        cmd_network()
+        printed = " ".join(str(c.args[0]) if c.args else "" for c in mock_console.print.call_args_list)
+        self.assertIn("Sin candidatos", printed)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mailer.py
+++ b/tests/test_mailer.py
@@ -74,5 +74,45 @@ class MailerTests(unittest.TestCase):
         self.assertIn("Candidato", msg["From"])
 
 
+class DomainAcceptsMailTests(unittest.TestCase):
+    def test_query_packet_ends_with_mx_qtype(self):
+        from jobhunter.mailer import _build_mx_query
+        pkt = _build_mx_query("acme.com", 0x1234)
+        self.assertEqual(pkt[:2], b"\x12\x34")
+        self.assertTrue(pkt.endswith(b"\x00\x0f\x00\x01"))
+        self.assertIn(b"\x04acme\x03com\x00", pkt)
+
+    def _resp(self, txid=0x1234, rcode=0, ancount=0):
+        import struct
+        flags = 0x8180 | rcode
+        return struct.pack(">HHHHHH", txid, flags, 1, ancount, 0, 0) + b"\x00" * 8
+
+    def test_parse_answers_means_mx_exists(self):
+        from jobhunter.mailer import _parse_mx_response
+        self.assertTrue(_parse_mx_response(self._resp(ancount=2), 0x1234))
+
+    def test_parse_nxdomain_is_false(self):
+        from jobhunter.mailer import _parse_mx_response
+        self.assertIs(_parse_mx_response(self._resp(rcode=3), 0x1234), False)
+
+    def test_parse_no_answers_is_false(self):
+        from jobhunter.mailer import _parse_mx_response
+        self.assertIs(_parse_mx_response(self._resp(ancount=0), 0x1234), False)
+
+    def test_parse_wrong_txid_is_none(self):
+        from jobhunter.mailer import _parse_mx_response
+        self.assertIsNone(_parse_mx_response(self._resp(txid=0x9999), 0x1234))
+
+    def test_parse_short_data_is_none(self):
+        from jobhunter.mailer import _parse_mx_response
+        self.assertIsNone(_parse_mx_response(b"\x00\x01", 0x1234))
+
+    def test_invalid_email_false_without_network(self):
+        from jobhunter.mailer import domain_accepts_mail
+        self.assertIs(domain_accepts_mail(""), False)
+        self.assertIs(domain_accepts_mail("sin-arroba"), False)
+        self.assertIs(domain_accepts_mail("x@sindominio"), False)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Que agrega

- **`jobhunter network`** — cola asistida de reclutadores: autores de los posts a los que ya aplicaste (capturados desde ahora en cada scrape), abre el perfil en TU navegador y tu das clic en Conectar; estado en `kb["network"]`. Cero automatizacion sobre LinkedIn (un baneo mataria tambien el scraping).
- **Validacion MX pre-envio** — consulta DNS MX cruda por UDP (stdlib) antes de enviar: dominio sin MX pide email alternativo (interactivo) u omite la oferta (`--auto`); fallo de red nunca bloquea. Verificado: `nuvelity.com` (el typo que causo un rebote real) da False, `nubelity.com` True.
- **Analitica por query** — cada aplicacion guarda la query que la origino + autor del post; `optimize` recibe un bloque `RENDIMIENTO REAL POR QUERY` (enviados/respuestas por query, via `sync`) con instruccion de expandir patrones que convierten y descartar los que no.

## Tests

197 en verde (21 nuevos). Spec y plan en `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbiZFrFNvVvCimgaapzY81