### PR TITLE
fix: nombre del autor legible en la cola de network

### DIFF
--- a/jobhunter/cli/network.py
+++ b/jobhunter/cli/network.py
@@ -5,6 +5,7 @@ Nunca automatiza acciones en LinkedIn: abre el perfil en el navegador por
 defecto (donde el usuario tiene su sesion normal) y es el usuario quien da
 clic en Conectar. Solo se lleva el registro en kb["network"].
 """
+import urllib.parse
 import webbrowser
 from datetime import datetime
 
@@ -14,6 +15,19 @@ from rich.prompt import Confirm, Prompt
 from jobhunter.banner import get_banner
 from jobhunter.storage import load_kb, save_kb
 from jobhunter.ui import console
+
+
+def _name_from_url(url):
+    """Nombre legible desde el slug del perfil cuando el post no lo trae.
+
+    "nicolas-villalba-958a5b46" -> "Nicolas Villalba" (el token final con
+    digitos es el id que LinkedIn agrega a slugs repetidos).
+    """
+    slug = urllib.parse.unquote((url or "").rstrip("/").rsplit("/in/", 1)[-1])
+    parts = [p for p in slug.split("-") if p]
+    if len(parts) > 1 and any(ch.isdigit() for ch in parts[-1]):
+        parts = parts[:-1]
+    return " ".join(p.capitalize() for p in parts) or "?"
 
 
 def build_network_queue(applications, network):
@@ -28,7 +42,7 @@ def build_network_queue(applications, network):
         seen.add(url)
         queue.append({
             "profile_url": url,
-            "name": a.get("author_name") or "?",
+            "name": a.get("author_name") or _name_from_url(url),
             "company": a.get("company") or "-",
             "job_title": a.get("job_title") or "-",
             "applied": (a.get("date") or "")[:10],

--- a/jobhunter/scraper.py
+++ b/jobhunter/scraper.py
@@ -137,10 +137,17 @@ def scrape_posts(page, query, max_scroll=4, time_filter="24h"):
             let author_url = null, author_name = null;
             const item = box.closest('[role="listitem"]');
             if (item) {
-                const a = item.querySelector('a[href*="/in/"]');
-                if (a) {
-                    author_url = (a.href || '').split('?')[0] || null;
-                    author_name = ((a.innerText || '').split('\n')[0] || '').trim() || null;
+                const anchors = [...item.querySelectorAll('a[href*="/in/"]')];
+                if (anchors.length) {
+                    author_url = (anchors[0].href || '').split('?')[0] || null;
+                    for (const a of anchors) {
+                        const t = (((a.innerText || '').split('\n')[0] || '').split('•')[0] || '').trim();
+                        if (t) { author_name = t; break; }
+                    }
+                    if (!author_name) {
+                        const img = item.querySelector('a[href*="/in/"] img[alt]');
+                        if (img) author_name = (img.getAttribute('alt') || '').trim() || null;
+                    }
                 }
             }
             const mapKey = (box.innerText || '').replace(/\s+/g, ' ').trim().slice(0, 120);

--- a/tests/test_cli_network.py
+++ b/tests/test_cli_network.py
@@ -29,6 +29,21 @@ class BuildNetworkQueueTests(unittest.TestCase):
         self.assertEqual(build_network_queue(None, None), [])
 
 
+class NameFromUrlTests(unittest.TestCase):
+    def test_derives_pretty_name_from_slug(self):
+        from jobhunter.cli.network import _name_from_url
+        self.assertEqual(_name_from_url("https://www.linkedin.com/in/nicolas-villalba-958a5b46/"), "Nicolas Villalba")
+        self.assertEqual(_name_from_url("https://linkedin.com/in/sabrinareiris"), "Sabrinareiris")
+        self.assertEqual(_name_from_url(""), "?")
+        self.assertEqual(_name_from_url(None), "?")
+
+    def test_queue_uses_slug_when_name_missing(self):
+        apps = [{"author_url": "https://linkedin.com/in/ana-perez-12ab34", "author_name": None,
+                 "date": "2026-08-01T10:00:00", "company": "X", "job_title": "Dev"}]
+        queue = build_network_queue(apps, [])
+        self.assertEqual(queue[0]["name"], "Ana Perez")
+
+
 class CmdNetworkTests(unittest.TestCase):
     @patch("jobhunter.cli.network.console")
     @patch("jobhunter.cli.network.save_kb")


### PR DESCRIPTION
El primer enlace /in/ del post es la foto del autor (sin texto), asi que author_name quedaba null y la cola mostraba "?". Tres capas: primer ancla con texto (limpiando "• 3.º"), fallback al alt de la imagen, y derivacion desde el slug de la URL para registros ya guardados. Verificado en vivo ("Sergio David Razo Jiménez", acentos incluidos). Los posts de paginas de empresa (sin enlace /in/) siguen correctamente fuera de la cola.

199 tests en verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbiZFrFNvVvCimgaapzY81