### PR TITLE
fix(ci): selftest del release esperaba mal el proceso GUI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,12 +35,10 @@ jobs:
       - name: Selftest del build congelado
         shell: pwsh
         run: |
-          & .\dist\JobHunter\JobHunter.exe --selftest
-          if ($LASTEXITCODE -ne 0) {
-            Get-Content "$env:TEMP\jobhunter_selftest.txt" -ErrorAction SilentlyContinue
-            exit 1
-          }
-          Get-Content "$env:TEMP\jobhunter_selftest.txt"
+          # La app es GUI (sin consola): hay que esperar el proceso explicitamente
+          $p = Start-Process -FilePath .\dist\JobHunter\JobHunter.exe -ArgumentList "--selftest" -Wait -PassThru
+          Get-Content "$env:TEMP\jobhunter_selftest.txt" -ErrorAction SilentlyContinue
+          if ($p.ExitCode -ne 0) { exit 1 }
 
       - name: Descargar bootstrapper WebView2
         shell: pwsh

--- a/desktop/packaging/build.ps1
+++ b/desktop/packaging/build.ps1
@@ -14,12 +14,10 @@ pyinstaller --noconfirm desktop/packaging/jobhunter.spec
 if ($LASTEXITCODE -ne 0) { throw "PyInstaller fallo" }
 
 Write-Host "== 3/4 Selftest ==" -ForegroundColor Cyan
-& "$repo\dist\JobHunter\JobHunter.exe" --selftest
-if ($LASTEXITCODE -ne 0) {
-    Get-Content "$env:TEMP\jobhunter_selftest.txt" -ErrorAction SilentlyContinue
-    throw "Selftest fallo"
-}
-Get-Content "$env:TEMP\jobhunter_selftest.txt"
+# La app es GUI (sin consola): esperar el proceso explicitamente
+$st = Start-Process -FilePath "$repo\dist\JobHunter\JobHunter.exe" -ArgumentList "--selftest" -Wait -PassThru
+Get-Content "$env:TEMP\jobhunter_selftest.txt" -ErrorAction SilentlyContinue
+if ($st.ExitCode -ne 0) { throw "Selftest fallo" }
 Write-Host "Selftest OK" -ForegroundColor Green
 
 if ($SkipInstaller) { Write-Host "Instalador omitido (-SkipInstaller)"; exit 0 }


### PR DESCRIPTION
En pwsh, `&` sobre un exe GUI retorna sin esperar y `$LASTEXITCODE` queda nulo → el job de release fallaba al instante aunque el build era correcto. Se cambia a `Start-Process -Wait -PassThru` y se chequea `.ExitCode` (release.yml y build.ps1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)