### PR TITLE
fix: el login de LinkedIn se reportaba como fallido aunque funcionara

### DIFF
--- a/desktop/packaging/version_info.txt
+++ b/desktop/packaging/version_info.txt
@@ -1,8 +1,8 @@
 # UTF-8
 VSVersionInfo(
   ffi=FixedFileInfo(
-    filevers=(2, 0, 0, 0),
-    prodvers=(2, 0, 0, 0),
+    filevers=(2, 0, 1, 0),
+    prodvers=(2, 0, 1, 0),
     mask=0x3f,
     flags=0x0,
     OS=0x40004,
@@ -15,12 +15,12 @@ VSVersionInfo(
       StringTable('040a04b0', [
         StringStruct('CompanyName', 'JobHunter AI'),
         StringStruct('FileDescription', 'JobHunter - Busqueda de empleo automatizada con IA'),
-        StringStruct('FileVersion', '2.0.0'),
+        StringStruct("FileVersion", "2.0.1"),
         StringStruct('InternalName', 'JobHunter'),
         StringStruct('LegalCopyright', 'MIT License - dev-gaspar'),
         StringStruct('OriginalFilename', 'JobHunter.exe'),
         StringStruct('ProductName', 'JobHunter'),
-        StringStruct('ProductVersion', '2.0.0')
+        StringStruct("ProductVersion", "2.0.1")
       ])
     ]),
     VarFileInfo([VarStruct('Translation', [1034, 1200])])

--- a/jobhunter/constants.py
+++ b/jobhunter/constants.py
@@ -21,7 +21,7 @@ CONFIG_PATH = os.path.join(BASE_DIR, "config.json")
 SESSION_DIR = os.path.join(BASE_DIR, ".session")
 KB_PATH = os.path.join(BASE_DIR, "knowledge.json")
 
-VERSION = "2.0.0"
+VERSION = "2.0.1"
 
 GEMINI_MODELS = [
     "gemini-2.5-flash",

--- a/jobhunter/scraper.py
+++ b/jobhunter/scraper.py
@@ -2,6 +2,7 @@
 """Scraping de LinkedIn via Playwright y login persistente."""
 import os
 import random
+import re
 import time
 import urllib.parse
 
@@ -163,6 +164,52 @@ def scrape_posts(page, query, max_scroll=4, time_filter="24h"):
     return posts
 
 
+LOGGED_IN_URL_RE = re.compile(r"(/feed|/in/|linkedin\.com/home)")
+
+
+def linkedin_session_ready(browser, page=None):
+    """True si el contexto ya tiene sesion util de LinkedIn.
+
+    La senal autoritativa es la cookie li_at: es lo que hace que la sesion
+    funcione, y no depende de en que pestana o ventana haya ocurrido el login.
+    La URL queda como respaldo por si cookies() falla.
+    """
+    try:
+        for c in browser.cookies():
+            if c.get("name") == "li_at" and c.get("value"):
+                return True
+    except Exception:
+        pass
+    if page is not None:
+        try:
+            return bool(LOGGED_IN_URL_RE.search(page.url))
+        except Exception:
+            return False
+    return False
+
+
+def wait_for_linkedin_session(browser, page, timeout_s=300, poll_ms=2000):
+    """Espera a que el login quede listo. Retorna True si hay sesion.
+
+    IMPORTANTE: la pausa se hace con page.wait_for_timeout, NO con time.sleep.
+    En la API sync de Playwright, page.url es un valor CACHEADO que solo se
+    refresca cuando el bucle de eventos del driver procesa mensajes; time.sleep
+    bloquea el hilo sin bombearlo, de modo que una navegacion hecha por el
+    USUARIO (completar el login) nunca llegaba al lado de Python y el login
+    valido se reportaba como fallido tras agotar el timeout.
+    """
+    start = time.monotonic()
+    while time.monotonic() - start < timeout_s:
+        if linkedin_session_ready(browser, page):
+            return True
+        try:
+            page.wait_for_timeout(poll_ms)
+        except Exception:
+            # La pestana se cerro: la sesion puede estar guardada de todos modos.
+            return linkedin_session_ready(browser, None)
+    return linkedin_session_ready(browser, None)
+
+
 def do_linkedin_login(interactive=True):
     """Flujo compartido de login en LinkedIn. Retorna True si la sesion quedo guardada.
 
@@ -192,19 +239,16 @@ def do_linkedin_login(interactive=True):
             page.goto("https://www.linkedin.com/login")
         except Exception:
             pass
-        console.print("  [dim]Esperando que completes el login y el 2FA (hasta 5 minutos)...[/dim]")
+        if interactive:
+            console.print("  [dim]Esperando que completes el login y el 2FA (hasta 5 minutos)...[/dim]")
 
-        start = time.time()
-        while time.time() - start < 300:
+        success = wait_for_linkedin_session(browser, page)
+        if success:
+            # Margen para que LinkedIn termine de asentar la sesion antes de cerrar.
             try:
-                url = page.url
-                if "/feed" in url or "/in/" in url or "linkedin.com/home" in url:
-                    time.sleep(3)
-                    success = True
-                    break
-                time.sleep(2)
+                page.wait_for_timeout(3000)
             except Exception:
-                break
+                pass
 
         try:
             browser.close()

--- a/tests/test_scraper_login_wait.py
+++ b/tests/test_scraper_login_wait.py
@@ -1,0 +1,140 @@
+# -*- coding: utf-8 -*-
+"""Tests de la espera de login en LinkedIn (regresion del bug de page.url obsoleto).
+
+CONTEXTO DEL BUG: en la API sync de Playwright, page.url es un valor CACHEADO que
+solo se refresca cuando el bucle de eventos del driver se bombea. time.sleep()
+bloquea el hilo sin bombearlo, asi que la navegacion que hace el USUARIO al
+iniciar sesion nunca llegaba al lado de Python: el login funcionaba pero se
+reportaba como fallido tras 5 minutos.
+
+Los fakes de abajo reproducen esa semantica: FakePage.url NO avanza solo; solo
+avanza cuando se llama a wait_for_timeout() (que es lo que bombea el loop). Un
+bucle implementado con time.sleep() NO puede pasar estos tests.
+"""
+import unittest
+
+from jobhunter.scraper import linkedin_session_ready, wait_for_linkedin_session
+
+LI_COOKIE = {"name": "li_at", "value": "AQEDAT...", "domain": ".www.linkedin.com"}
+OTHER_COOKIE = {"name": "bcookie", "value": "v=2", "domain": ".linkedin.com"}
+
+
+class FakeBrowser:
+    """Contexto falso: expone cookies() y cuenta los bombeos del loop."""
+
+    def __init__(self, cookie_after_pumps=None, raise_on_cookies=False):
+        self.pumps = 0
+        self._cookie_after = cookie_after_pumps
+        self._raise = raise_on_cookies
+
+    def cookies(self):
+        if self._raise:
+            raise RuntimeError("contexto cerrado")
+        if self._cookie_after is not None and self.pumps >= self._cookie_after:
+            return [OTHER_COOKIE, LI_COOKIE]
+        return [OTHER_COOKIE]
+
+
+class FakePage:
+    """Pagina falsa con la semantica REAL de Playwright sync.
+
+    `url` devuelve un valor cacheado. Solo wait_for_timeout() (que bombea el
+    bucle de eventos) hace avanzar ese cache a la siguiente URL real.
+    """
+
+    def __init__(self, browser, urls, raise_on_wait=False):
+        self.browser = browser
+        self._urls = list(urls)
+        self._i = 0
+        self._raise_on_wait = raise_on_wait
+        self.waits = []
+
+    @property
+    def url(self):
+        return self._urls[self._i]
+
+    def wait_for_timeout(self, ms):
+        if self._raise_on_wait:
+            raise RuntimeError("Target page, context or browser has been closed")
+        self.waits.append(ms)
+        self.browser.pumps += 1
+        self._i = min(self._i + 1, len(self._urls) - 1)
+
+
+class WaitForLinkedinSessionTests(unittest.TestCase):
+    def test_detects_login_by_cookie(self):
+        """La cookie li_at es la senal autoritativa: aparece tras 2 bombeos."""
+        browser = FakeBrowser(cookie_after_pumps=2)
+        page = FakePage(browser, ["https://www.linkedin.com/login"])
+        self.assertTrue(wait_for_linkedin_session(browser, page, timeout_s=5, poll_ms=1))
+
+    def test_detects_login_by_url_when_cookie_missing(self):
+        """Sin cookie visible, la URL del feed tambien vale (fallback)."""
+        browser = FakeBrowser(cookie_after_pumps=None)
+        page = FakePage(browser, [
+            "https://www.linkedin.com/login",
+            "https://www.linkedin.com/checkpoint/challenge",
+            "https://www.linkedin.com/feed/",
+        ])
+        self.assertTrue(wait_for_linkedin_session(browser, page, timeout_s=5, poll_ms=1))
+
+    def test_pumps_the_event_loop(self):
+        """REGRESION: debe usarse page.wait_for_timeout, no time.sleep.
+
+        Si el bucle usara time.sleep, no habria bombeos y la URL jamas avanzaria.
+        """
+        browser = FakeBrowser(cookie_after_pumps=None)
+        page = FakePage(browser, [
+            "https://www.linkedin.com/login",
+            "https://www.linkedin.com/feed/",
+        ])
+        wait_for_linkedin_session(browser, page, timeout_s=5, poll_ms=7)
+        self.assertGreater(len(page.waits), 0, "no se bombeo el bucle de eventos")
+        self.assertEqual(page.waits[0], 7)
+
+    def test_returns_false_on_timeout(self):
+        browser = FakeBrowser(cookie_after_pumps=None)
+        page = FakePage(browser, ["https://www.linkedin.com/login"])
+        self.assertFalse(wait_for_linkedin_session(browser, page, timeout_s=0.05, poll_ms=1))
+
+    def test_page_closed_still_checks_cookies(self):
+        """Si el usuario cierra la pestana pero la sesion existe, es exito."""
+        browser = FakeBrowser(cookie_after_pumps=0)  # cookie ya presente
+        page = FakePage(browser, ["about:blank"], raise_on_wait=True)
+        self.assertTrue(wait_for_linkedin_session(browser, page, timeout_s=5, poll_ms=1))
+
+    def test_page_closed_without_session_is_failure(self):
+        browser = FakeBrowser(cookie_after_pumps=None)
+        page = FakePage(browser, ["about:blank"], raise_on_wait=True)
+        self.assertFalse(wait_for_linkedin_session(browser, page, timeout_s=5, poll_ms=1))
+
+    def test_detects_session_saved_in_another_tab(self):
+        """La cookie no depende de la pestana: login en otra ventana igual cuenta."""
+        browser = FakeBrowser(cookie_after_pumps=1)
+        page = FakePage(browser, ["https://www.linkedin.com/login"])  # esta pestana nunca cambia
+        self.assertTrue(wait_for_linkedin_session(browser, page, timeout_s=5, poll_ms=1))
+
+
+class LinkedinSessionReadyTests(unittest.TestCase):
+    def test_true_with_cookie(self):
+        self.assertTrue(linkedin_session_ready(FakeBrowser(cookie_after_pumps=0), None))
+
+    def test_false_without_cookie_or_url(self):
+        browser = FakeBrowser(cookie_after_pumps=None)
+        page = FakePage(browser, ["https://www.linkedin.com/login"])
+        self.assertFalse(linkedin_session_ready(browser, page))
+
+    def test_ignores_empty_cookie_value(self):
+        class Empty(FakeBrowser):
+            def cookies(self):
+                return [{"name": "li_at", "value": "", "domain": ".www.linkedin.com"}]
+        self.assertFalse(linkedin_session_ready(Empty(), None))
+
+    def test_survives_cookies_error(self):
+        browser = FakeBrowser(raise_on_cookies=True)
+        page = FakePage(browser, ["https://www.linkedin.com/feed/"])
+        self.assertTrue(linkedin_session_ready(browser, page))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Sintoma

En el onboarding de la app, el paso *Conecta LinkedIn* se queda 5 minutos en el spinner y luego dice que no detecto el login, aunque el usuario ya inicio sesion y el navegador muestra el feed. En el CLI (`jobhunter login`) el mismo bug se veia como un aviso confuso: decia que fallo, pero `jobhunter run` funcionaba igual.

## Causa raiz

```python
url = page.url    # valor CACHEADO
time.sleep(2)     # bloquea el hilo sin bombear el event loop de Playwright
```

En la API sync de Playwright `page.url` no consulta al navegador: devuelve el ultimo valor que el driver comunico, y ese valor solo se actualiza cuando el bucle de eventos procesa mensajes. `time.sleep()` bloquea el hilo sin dejarlo correr, asi que **una navegacion disparada por el usuario nunca llega al lado de Python**.

Comprobado de forma aislada: programando una navegacion dentro del navegador, el bucle viejo leyo la URL 7 veces en 14s y siempre devolvio la vieja; un solo `page.evaluate` la destapo al instante.

## Arreglo

`wait_for_linkedin_session(browser, page)`:
- pausa con `page.wait_for_timeout` en vez de `time.sleep` (bombea el loop)
- decide por la cookie **`li_at`**, que es lo que realmente hace usable la sesion y no depende de la pestana donde ocurra el login
- si la pestana se cierra, revisa cookies antes de dar por fallido

## Verificacion

- 11 tests nuevos con fakes que replican la semantica de cache (un bucle con `time.sleep` no los puede pasar). Suite completa: 255 tests verdes.
- Contra Edge real: navegacion disparada por el navegador detectada en **4.1s** (antes: nunca en 300s); perfil con sesion previa detectado en **0.05s** sin navegar.
- Verificado por separado que `evaluate_js` desde hilo de fondo si entrega eventos a la UI (se descarto como causa).

🤖 Generated with [Claude Code](https://claude.com/claude-code)